### PR TITLE
Aspect ratio based render target matching

### DIFF
--- a/src/AddonUIDisplay.h
+++ b/src/AddonUIDisplay.h
@@ -311,7 +311,9 @@ static void DisplayRenderTargets(AddonImGui::AddonUIData& instance, Rendering::R
     uint32_t selectedIndex = group->getInvocationLocation();
 
     bool retry = group->getRequeueAfterRTMatchingFailure();
-    bool matchRes = group->getMatchSwapchainResolution();
+    static const char* swapchainMatchOptions[] = { "RESOLUTION", "ASPECT RATIO", "NONE"};
+    uint32_t selectedSwapchainMatchMode = group->getMatchSwapchainResolution();
+    const char* typesSelectedSwapchainMatchMode = swapchainMatchOptions[selectedSwapchainMatchMode];
 
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
     if (ImGui::BeginChild("RenderTargets", { 0, height / 1.5f }, true, ImGuiWindowFlags_AlwaysAutoResize))
@@ -374,15 +376,29 @@ static void DisplayRenderTargets(AddonImGui::AddonUIData& instance, Rendering::R
             ImGui::TableNextRow();
             ImGui::TableNextColumn();
 
-            ImGui::Text("Match swapchain resolution");
+            ImGui::Text("Match swapchain");
             ImGui::TableNextColumn();
-            ImGui::Checkbox("##Matchswapchainresolution", &matchRes);
+            if (ImGui::BeginCombo("##effSwapChainMatchMode", typesSelectedSwapchainMatchMode, ImGuiComboFlags_None))
+            {
+                for (int n = 0; n < IM_ARRAYSIZE(swapchainMatchOptions); n++)
+                {
+                    bool is_selected = (typesSelectedSwapchainMatchMode == swapchainMatchOptions[n]);
+                    if (ImGui::Selectable(swapchainMatchOptions[n], is_selected))
+                    {
+                        typesSelectedSwapchainMatchMode = swapchainMatchOptions[n];
+                        selectedSwapchainMatchMode = n;
+                    }
+                    if (is_selected)
+                        ImGui::SetItemDefaultFocus();
+                }
+                ImGui::EndCombo();
+            }
 
             ImGui::EndTable();
         }
 
         group->setRequeueAfterRTMatchingFailure(retry);
-        group->setMatchSwapchainResolution(matchRes);
+        group->setMatchSwapchainResolution(selectedSwapchainMatchMode);
         group->setInvocationLocation(selectedIndex);
 
         ImGui::Separator();
@@ -467,6 +483,10 @@ static void DisplayTextureBindings(AddonImGui::AddonUIData& instance, ShaderTogg
     const char* typeSelectedItem = typeItems[selectedIndex];
     DeviceDataContainer& deviceData = runtime->get_device()->get_private_data<DeviceDataContainer>();
 
+    static const char* swapchainMatchOptions[] = { "RESOLUTION", "ASPECT RATIO", "NONE" };
+    uint32_t selectedSwapchainMatchMode = group->getBindingMatchSwapchainResolution();
+    const char* typesSelectedSwapchainMatchMode = swapchainMatchOptions[selectedSwapchainMatchMode];
+
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
     if (ImGui::BeginChild("Texture bindings viewer", { 0, height / 2.0f }, true, ImGuiWindowFlags_AlwaysAutoResize))
     {
@@ -483,7 +503,6 @@ static void DisplayTextureBindings(AddonImGui::AddonUIData& instance, ShaderTogg
 
         bool copyBinding = group->getCopyTextureBinding();
         bool clearBinding = group->getClearBindings();
-        bool matchSwapchain = group->getBindingMatchSwapchainResolution();
 
         if (ImGui::BeginTable("Bindingsettings", 2, ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_NoBordersInBody))
         {
@@ -682,12 +701,26 @@ static void DisplayTextureBindings(AddonImGui::AddonUIData& instance, ShaderTogg
                 }
 
                 ImGui::TableNextColumn();
-                ImGui::Text("Match swapchain resolution");
+                ImGui::Text("Match swapchain");
                 ImGui::TableNextColumn();
-                ImGui::Checkbox("##BindingMatchswapchainresolution", &matchSwapchain);
+                if (ImGui::BeginCombo("##swapChainMatchMode", typesSelectedSwapchainMatchMode, ImGuiComboFlags_None))
+                {
+                    for (int n = 0; n < IM_ARRAYSIZE(swapchainMatchOptions); n++)
+                    {
+                        bool is_selected = (typesSelectedSwapchainMatchMode == swapchainMatchOptions[n]);
+                        if (ImGui::Selectable(swapchainMatchOptions[n], is_selected))
+                        {
+                            typesSelectedSwapchainMatchMode = swapchainMatchOptions[n];
+                            selectedSwapchainMatchMode = n;
+                        }
+                        if (is_selected)
+                            ImGui::SetItemDefaultFocus();
+                    }
+                    ImGui::EndCombo();
+                }
 
                 group->setBindingInvocationLocation(rtSelectedIndex);
-                group->setBindingMatchSwapchainResolution(matchSwapchain);
+                group->setBindingMatchSwapchainResolution(selectedSwapchainMatchMode);
             }
 
             ImGui::EndTable();

--- a/src/RenderingManager.cpp
+++ b/src/RenderingManager.cpp
@@ -256,12 +256,13 @@ const resource_view RenderingManager::GetCurrentResourceView(command_list* cmd_l
 
         resource_desc desc = device->get_resource_desc(rs);
 
-        if (group->getBindingMatchSwapchainResolution())
+        if (group->getBindingMatchSwapchainResolution() < ShaderToggler::SWAPCHAIN_MATCH_MODE_NONE)
         {
             uint32_t width, height;
             deviceData.current_runtime->get_screenshot_width_and_height(&width, &height);
 
-            if (width != desc.texture.width || height != desc.texture.height)
+            if ((group->getBindingMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_ASPECT_RATIO && static_cast<float>(width) / height != static_cast<float>(desc.texture.width) / desc.texture.height) ||
+                (group->getBindingMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_RESOLUTION && (width != desc.texture.width || height != desc.texture.height)))
             {
                 return active_rtv;
             }
@@ -287,12 +288,13 @@ const resource_view RenderingManager::GetCurrentResourceView(command_list* cmd_l
         }
 
         // Make sure our target matches swap buffer dimensions when applying effects or it's explicitly requested
-        if (group->getMatchSwapchainResolution())
+        if (group->getMatchSwapchainResolution() < ShaderToggler::SWAPCHAIN_MATCH_MODE_NONE)
         {
             uint32_t width, height;
             deviceData.current_runtime->get_screenshot_width_and_height(&width, &height);
 
-            if (width != desc.texture.width || height != desc.texture.height)
+            if ((group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_ASPECT_RATIO && static_cast<float>(width) / height != static_cast<float>(desc.texture.width) / desc.texture.height) ||
+                (group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_RESOLUTION && (width != desc.texture.width || height != desc.texture.height)))
             {
                 return active_rtv;
             }
@@ -337,12 +339,13 @@ const resource_view RenderingManager::GetCurrentPreviewResourceView(command_list
         resource_desc desc = device->get_resource_desc(rs);
 
         // Make sure our target matches swap buffer dimensions when applying effects or it's explicitly requested
-        if (group->getMatchSwapchainResolution())
+        if (group->getMatchSwapchainResolution() < ShaderToggler::SWAPCHAIN_MATCH_MODE_NONE)
         {
             uint32_t width, height;
             deviceData.current_runtime->get_screenshot_width_and_height(&width, &height);
 
-            if (width != desc.texture.width || height != desc.texture.height)
+            if ((group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_ASPECT_RATIO && static_cast<float>(width) / height != static_cast<float>(desc.texture.width) / desc.texture.height) ||
+                (group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_RESOLUTION && (width != desc.texture.width || height != desc.texture.height)))
             {
                 return active_rtv;
             }

--- a/src/ToggleGroup.cpp
+++ b/src/ToggleGroup.cpp
@@ -182,7 +182,7 @@ namespace ShaderToggler
         }
         iniFile.SetUInt("RenderTargetIndex", _rtIndex, "", sectionRoot);
         iniFile.SetUInt("InvocationLocation", _invocationLocation, "", sectionRoot);
-        iniFile.SetBool("MatchSwapchainResolutionOnly", _matchSwapchainResolution, "", sectionRoot);
+        iniFile.SetUInt("MatchSwapchainResolutionOnly", _matchSwapchainResolution, "", sectionRoot);
         iniFile.SetBool("RequeueAfterRTMatchingFailure", _requeueAfterRTMatchingFailure, "", sectionRoot);
 
         iniFile.SetValue("Techniques", ss.str(), "", sectionRoot);
@@ -203,7 +203,7 @@ namespace ShaderToggler
         iniFile.SetUInt("SRVDescriptorIndex", _bindingSrvDescIndex, "", sectionRoot);
         iniFile.SetUInt("BindingRenderTargetIndex", _bindingRTIndex, "", sectionRoot);
         iniFile.SetUInt("BindingInvocationLocation", _bindingInvocationLocation, "", sectionRoot);
-        iniFile.SetBool("BindingMatchSwapchainResolutionOnly", _bindingMatchSwapchainResolution, "", sectionRoot);
+        iniFile.SetUInt("BindingMatchSwapchainResolutionOnly", _bindingMatchSwapchainResolution, "", sectionRoot);
     }
 
 
@@ -298,7 +298,12 @@ namespace ShaderToggler
             _invocationLocation = 0;
         }
 
-        _matchSwapchainResolution = iniFile.GetBoolOrDefault("MatchSwapchainResolutionOnly", sectionRoot, true);
+        _matchSwapchainResolution = iniFile.GetUInt("MatchSwapchainResolutionOnly", sectionRoot);
+        if (_matchSwapchainResolution == UINT_MAX)
+        {
+            _matchSwapchainResolution = SWAPCHAIN_MATCH_MODE_RESOLUTION; //fallback to effect invocation location when loading old configs
+        }
+
         _requeueAfterRTMatchingFailure = iniFile.GetBoolOrDefault("RequeueAfterRTMatchingFailure", sectionRoot, false);
 
         std::string techniques = iniFile.GetString("Techniques", sectionRoot);
@@ -395,6 +400,10 @@ namespace ShaderToggler
             _bindingInvocationLocation = _invocationLocation; //fallback to effect invocation location when loading old configs
         }
 
-        _bindingMatchSwapchainResolution = iniFile.GetBoolOrDefault("BindingMatchSwapchainResolutionOnly", sectionRoot, _matchSwapchainResolution);
+        _bindingMatchSwapchainResolution = iniFile.GetUInt("BindingMatchSwapchainResolutionOnly", sectionRoot);
+        if(_bindingMatchSwapchainResolution == UINT_MAX)
+        {
+            _bindingMatchSwapchainResolution = _matchSwapchainResolution; //fallback to effect invocation location when loading old configs
+        }
     }
 }

--- a/src/ToggleGroup.h
+++ b/src/ToggleGroup.h
@@ -46,6 +46,13 @@ namespace ShaderToggler
         CYCLE_DOWN
     };
 
+    enum SwapChainMatchMode : uint32_t
+    {
+        SWAPCHAIN_MATCH_MODE_RESOLUTION = 0,
+        SWAPCHAIN_MATCH_MODE_ASPECT_RATIO = 1,
+        SWAPCHAIN_MATCH_MODE_NONE = 2
+    };
+
     class ToggleGroup
     {
     public:
@@ -116,10 +123,10 @@ namespace ShaderToggler
         uint32_t getBindingRenderTargetIndex() const { return _bindingRTIndex; }
         bool getHasTechniqueExceptions() const { return _hasTechniqueExceptions; }
         void setHasTechniqueExceptions(bool exceptions) { _hasTechniqueExceptions = exceptions; }
-        bool getMatchSwapchainResolution() const { return _matchSwapchainResolution; }
-        void setMatchSwapchainResolution(bool match) { _matchSwapchainResolution = match; }
-        bool getBindingMatchSwapchainResolution() const { return _bindingMatchSwapchainResolution; }
-        void setBindingMatchSwapchainResolution(bool match) { _bindingMatchSwapchainResolution = match; }
+        uint32_t getMatchSwapchainResolution() const { return _matchSwapchainResolution; }
+        void setMatchSwapchainResolution(uint32_t match) { _matchSwapchainResolution = match; }
+        uint32_t getBindingMatchSwapchainResolution() const { return _bindingMatchSwapchainResolution; }
+        void setBindingMatchSwapchainResolution(uint32_t match) { _bindingMatchSwapchainResolution = match; }
         bool getRequeueAfterRTMatchingFailure() const { return _requeueAfterRTMatchingFailure; }
         void setRequeueAfterRTMatchingFailure(bool requeue) { _requeueAfterRTMatchingFailure = requeue; }
         bool getCopyTextureBinding() const { return _copyTextureBinding; }
@@ -177,8 +184,8 @@ namespace ShaderToggler
         bool _extractResourceViews;
         bool _clearBindings;
         bool _hasTechniqueExceptions; // _preferredTechniques are handled as exception to _allowAllTechniques
-        bool _matchSwapchainResolution = true;
-        bool _bindingMatchSwapchainResolution = true;
+        uint32_t _matchSwapchainResolution = SWAPCHAIN_MATCH_MODE_RESOLUTION;
+        uint32_t _bindingMatchSwapchainResolution = SWAPCHAIN_MATCH_MODE_RESOLUTION;
         bool _requeueAfterRTMatchingFailure;
         std::string _textureBindingName;
         std::unordered_set<std::string> _preferredTechniques;


### PR DESCRIPTION
Make it possible to consider render targets matching the swapchain's aspect ratio to be valid instead of just the resolution. Useful for some game with upscale techniques.