### PR TITLE
Restore correct stencil reference value

### DIFF
--- a/src/StateTracking.cpp
+++ b/src/StateTracking.cpp
@@ -30,6 +30,8 @@ void state_block::apply(command_list* cmd_list) const
         cmd_list->bind_pipeline_state(dynamic_state::primitive_topology, static_cast<uint32_t>(primitive_topology));
     if (blend_constant != 0)
         cmd_list->bind_pipeline_state(dynamic_state::blend_constant, blend_constant);
+    if (front_stencil_reference_value != 0)
+        cmd_list->bind_pipeline_state(dynamic_state::front_stencil_reference_value, front_stencil_reference_value);
 
     if (!viewports.empty())
         cmd_list->bind_viewports(0, static_cast<uint32_t>(viewports.size()), viewports.data());
@@ -80,6 +82,8 @@ void state_block::clear()
     depth_stencil = { 0 };
     primitive_topology = primitive_topology::undefined;
     blend_constant = 0;
+    front_stencil_reference_value = 0;
+    back_stencil_reference_value = 0;
     viewports.clear();
     scissor_rects.clear();
     descriptor_tables.fill(make_pair(pipeline_layout{ 0 }, std::vector<descriptor_table>()));
@@ -159,6 +163,12 @@ static void on_bind_pipeline_states(command_list* cmd_list, uint32_t count, cons
             break;
         case dynamic_state::blend_constant:
             state.blend_constant = values[i];
+            break;
+        case dynamic_state::front_stencil_reference_value:
+            state.front_stencil_reference_value = values[i];
+            break;
+        case dynamic_state::back_stencil_reference_value:
+            state.back_stencil_reference_value = values[i];
             break;
         }
     }

--- a/src/StateTracking.h
+++ b/src/StateTracking.h
@@ -62,6 +62,8 @@ namespace StateTracking
         std::array<reshade::api::pipeline_stage, ALL_PIPELINE_STAGES_SIZE> current_pipeline_stage;
         reshade::api::primitive_topology primitive_topology = reshade::api::primitive_topology::undefined;
         uint32_t blend_constant = 0;
+        uint32_t front_stencil_reference_value = 0;
+        uint32_t back_stencil_reference_value = 0;
         std::vector<reshade::api::viewport> viewports;
         std::vector<reshade::api::rect> scissor_rects;
         std::array<std::pair<reshade::api::pipeline_layout, std::vector<reshade::api::descriptor_table>>, ALL_SHADER_STAGES_SIZE> descriptor_tables;


### PR DESCRIPTION
Previously it would only restore a default value, overriding whatever was set by the game