### PR TITLE
Improved DX12 state tracking for next ReShade version and preview alpha clearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,6 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Shaders
+*.cso

--- a/src/AddonUIDisplay.h
+++ b/src/AddonUIDisplay.h
@@ -245,7 +245,7 @@ static void DrawPreview(unsigned long long textureId, uint32_t srcWidth, uint32_
     ImGui::PopStyleVar();
 }
 
-static void DisplayPreview(AddonImGui::AddonUIData& instance, Rendering::ResourceManager& resManager, reshade::api::effect_runtime* runtime, float width = 0)
+static void DisplayPreview(AddonImGui::AddonUIData& instance, Rendering::ResourceManager& resManager, reshade::api::effect_runtime* runtime, ShaderToggler::ToggleGroup* group, float width = 0)
 {
     if (ImGui::BeginChild("RTPreview##child", { width, 0 }, true, ImGuiWindowFlags_None))
     {
@@ -254,6 +254,7 @@ static void DisplayPreview(AddonImGui::AddonUIData& instance, Rendering::Resourc
         DeviceDataContainer& deviceData = runtime->get_device()->get_private_data<DeviceDataContainer>();
         reshade::api::resource_view srv = reshade::api::resource_view{ 0 };
         resManager.SetPreviewViewHandles(nullptr, nullptr, &srv);
+        bool clearAlpha = group->getClearPreviewAlpha();
 
         if (srv != 0)
         {
@@ -262,6 +263,10 @@ static void DisplayPreview(AddonImGui::AddonUIData& instance, Rendering::Resourc
             ImGui::Text(std::format("Width: {} ", deviceData.huntPreview.width).c_str());
             ImGui::SameLine();
             ImGui::Text(std::format("Height: {} ", deviceData.huntPreview.height).c_str());
+            ImGui::SameLine();
+            ImGui::Text("Clear alpha channel");
+            ImGui::SameLine();
+            ImGui::Checkbox("##Clearalpha", &clearAlpha);
             ImGui::Separator();
 
             if (ImGui::BeginChild("RTPreview##preview", { 0, 0 }, false, ImGuiWindowFlags_None))
@@ -270,6 +275,8 @@ static void DisplayPreview(AddonImGui::AddonUIData& instance, Rendering::Resourc
             }
             ImGui::EndChild();
         }
+
+        group->setClearPreviewAlpha(clearAlpha);
 
         ImGui::PopStyleVar();
     }
@@ -422,7 +429,7 @@ static void DisplayRenderTargets(AddonImGui::AddonUIData& instance, Rendering::R
     if (ImGui::IsItemActive())
         height += ImGui::GetIO().MouseDelta.y;
 
-    DisplayPreview(instance, resManager, runtime);
+    DisplayPreview(instance, resManager, runtime, group);
 
     ImGui::PopStyleVar();
 }

--- a/src/AddonUIDisplay.h
+++ b/src/AddonUIDisplay.h
@@ -253,7 +253,7 @@ static void DisplayPreview(AddonImGui::AddonUIData& instance, Rendering::Resourc
 
         DeviceDataContainer& deviceData = runtime->get_device()->get_private_data<DeviceDataContainer>();
         reshade::api::resource_view srv = reshade::api::resource_view{ 0 };
-        resManager.SetPreviewViewHandles(nullptr, nullptr, &srv);
+        resManager.SetPongPreviewHandles(nullptr, nullptr, &srv);
         bool clearAlpha = group->getClearPreviewAlpha();
 
         ImGui::Text("Clear alpha channel");
@@ -292,7 +292,7 @@ static void DisplayBindingPreview(AddonImGui::AddonUIData& instance, Rendering::
 
         DeviceDataContainer& deviceData = runtime->get_device()->get_private_data<DeviceDataContainer>();
         reshade::api::resource_view srv = reshade::api::resource_view{ 0 };
-        resManager.SetPreviewViewHandles(nullptr, nullptr, &srv);
+        resManager.SetPongPreviewHandles(nullptr, nullptr, &srv);
         const auto& it = deviceData.bindingMap.find(binding);
 
         if (it != deviceData.bindingMap.end())

--- a/src/AddonUIDisplay.h
+++ b/src/AddonUIDisplay.h
@@ -256,17 +256,18 @@ static void DisplayPreview(AddonImGui::AddonUIData& instance, Rendering::Resourc
         resManager.SetPreviewViewHandles(nullptr, nullptr, &srv);
         bool clearAlpha = group->getClearPreviewAlpha();
 
+        ImGui::Text("Clear alpha channel");
+        ImGui::SameLine();
+        ImGui::Checkbox("##Clearalpha", &clearAlpha);
+
         if (srv != 0)
         {
-            ImGui::Text(std::format("Format: {} ", static_cast<uint32_t>(deviceData.huntPreview.format)).c_str());
+            ImGui::SameLine();
+            ImGui::Text(std::format(" Format: {} ", static_cast<uint32_t>(deviceData.huntPreview.format)).c_str());
             ImGui::SameLine();
             ImGui::Text(std::format("Width: {} ", deviceData.huntPreview.width).c_str());
             ImGui::SameLine();
             ImGui::Text(std::format("Height: {} ", deviceData.huntPreview.height).c_str());
-            ImGui::SameLine();
-            ImGui::Text("Clear alpha channel");
-            ImGui::SameLine();
-            ImGui::Checkbox("##Clearalpha", &clearAlpha);
             ImGui::Separator();
 
             if (ImGui::BeginChild("RTPreview##preview", { 0, 0 }, false, ImGuiWindowFlags_None))

--- a/src/AddonUIDisplay.h
+++ b/src/AddonUIDisplay.h
@@ -202,27 +202,6 @@ static void DisplayTechniqueSelection(AddonImGui::AddonUIData& instance, ShaderT
         group->setPreferredTechniques(newTechniques);
 }
 
-struct DrawCallData
-{
-    reshade::api::effect_runtime* runtime = nullptr;
-    bool isAfter = false;
-};
-
-static DrawCallData callbackdatabefore = DrawCallData{ nullptr, false };
-static DrawCallData callbackdataafter = DrawCallData{ nullptr, true };
-
-static void render_function(const ImDrawList* parent_list, const ImDrawCmd* cmd)
-{
-    DrawCallData* callData = reinterpret_cast<DrawCallData*>(cmd->UserCallbackData);
-    reshade::api::effect_runtime* runtime = callData->runtime;
-    reshade::api::command_list* cmd_list = runtime->get_command_queue()->get_immediate_command_list();
-
-    if(!callData->isAfter)
-        cmd_list->bind_pipeline_state(reshade::api::dynamic_state::blend_constant, 0x00FFFFFF);
-    else
-        cmd_list->bind_pipeline_state(reshade::api::dynamic_state::blend_constant, 0xffffffff);
-}
-
 static void DrawPreview(unsigned long long textureId, uint32_t srcWidth, uint32_t srcHeight)
 {
     ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));

--- a/src/ConstantHandlerBase.cpp
+++ b/src/ConstantHandlerBase.cpp
@@ -181,7 +181,7 @@ bool ConstantHandlerBase::UpdateConstantBufferEntries(command_list* cmd_list, Co
             desc = std::min(++desc, desc_size - 1);
             buf = state.get_descriptor_at(index, slot, desc);
 
-            while (buf != nullptr && buf->constant.buffer == 0 && desc < desc_size - 2)
+            while ((buf == nullptr || buf->constant.buffer == 0) && desc < desc_size - 2)
             {
                 buf = state.get_descriptor_at(index, slot, ++desc);
             }
@@ -191,7 +191,7 @@ bool ConstantHandlerBase::UpdateConstantBufferEntries(command_list* cmd_list, Co
             desc = desc > 0 ? --desc : 0;
             buf = state.get_descriptor_at(index, slot, desc);
 
-            while (buf != nullptr && buf->constant.buffer == 0 && desc > 0)
+            while ((buf == nullptr || buf->constant.buffer == 0) && desc > 0)
             {
                 buf = state.get_descriptor_at(index, slot, --desc);
             }

--- a/src/ConstantHandlerBase.cpp
+++ b/src/ConstantHandlerBase.cpp
@@ -159,7 +159,7 @@ bool ConstantHandlerBase::UpdateConstantBufferEntries(command_list* cmd_list, Co
     state_tracking& state = cmd_list->get_private_data<state_tracking>();
     index = std::min(static_cast<uint32_t>(2), index);
 
-    const auto& [_, current_descriptors] = state.descriptors[index];
+    const auto& [_, current_descriptors] = state.push_descriptors[index];
 
     int32_t slot_size = static_cast<int32_t>(current_descriptors.size());
     int32_t slot = std::min(static_cast<int32_t>(group->getCBSlotIndex()), slot_size - 1);

--- a/src/ConstantHandlerBase.cpp
+++ b/src/ConstantHandlerBase.cpp
@@ -159,21 +159,19 @@ bool ConstantHandlerBase::UpdateConstantBufferEntries(command_list* cmd_list, Co
     state_tracking& state = cmd_list->get_private_data<state_tracking>();
     index = std::min(static_cast<uint32_t>(2), index);
 
-    const auto& [_, current_descriptors] = state.push_descriptors[index];
-
-    int32_t slot_size = static_cast<int32_t>(current_descriptors.size());
+    int32_t slot_size = static_cast<int32_t>(state.get_root_table_size_at(index));
     int32_t slot = std::min(static_cast<int32_t>(group->getCBSlotIndex()), slot_size - 1);
 
     if (slot_size <= 0)
         return false;
 
-    int32_t desc_size = static_cast<int32_t>(current_descriptors[slot].size());
+    int32_t desc_size = static_cast<int32_t>(state.get_root_table_entry_size_at(index, slot));
     int32_t desc = std::min(static_cast<int32_t>(group->getCBDescriptorIndex()), desc_size - 1);
 
     if (desc_size <= 0)
         return false;
 
-    descriptor_tracking::descriptor_data buf = current_descriptors[slot][desc];
+    const descriptor_tracking::descriptor_data* buf = state.get_descriptor_at(index, slot, desc);
 
     DescriptorCycle cycle = group->consumeCBCycle();
     if (cycle != CYCLE_NONE)
@@ -181,35 +179,35 @@ bool ConstantHandlerBase::UpdateConstantBufferEntries(command_list* cmd_list, Co
         if (cycle == CYCLE_UP)
         {
             desc = std::min(++desc, desc_size - 1);
-            buf = current_descriptors[slot][desc];
+            buf = state.get_descriptor_at(index, slot, desc);
 
-            while (buf.constant.buffer == 0 && desc < desc_size - 2)
+            while (buf != nullptr && buf->constant.buffer == 0 && desc < desc_size - 2)
             {
-                buf = current_descriptors[slot][++desc];
+                buf = state.get_descriptor_at(index, slot, ++desc);
             }
         }
         else
         {
             desc = desc > 0 ? --desc : 0;
-            buf = current_descriptors[slot][desc];
+            buf = state.get_descriptor_at(index, slot, desc);
 
-            while (buf.constant.buffer == 0 && desc > 0)
+            while (buf != nullptr && buf->constant.buffer == 0 && desc > 0)
             {
-                buf = current_descriptors[slot][--desc];
+                buf = state.get_descriptor_at(index, slot, --desc);
             }
         }
 
-        if (buf.constant.buffer != 0)
+        if (buf != nullptr && buf->constant.buffer != 0)
         {
             group->setCBDescriptorIndex(desc);
         }
     }
 
-    if (buf.constant.buffer != 0)
+    if (buf != nullptr && buf->constant.buffer != 0)
     {
         unique_lock<shared_mutex>(groupBufferMutex);
 
-        SetBufferRange(group, buf.constant, cmd_list->get_device(), cmd_list);
+        SetBufferRange(group, buf->constant, cmd_list->get_device(), cmd_list);
         ApplyConstantValues(devData.current_runtime, group, restVariables);
         devData.constantsUpdated.insert(group);
 
@@ -224,26 +222,29 @@ bool ConstantHandlerBase::UpdateConstantEntries(command_list* cmd_list, CommandL
     state_tracking& state = cmd_list->get_private_data<state_tracking>();
     index = std::min(static_cast<uint32_t>(2), index);
 
-    const auto& [_, current_constants] = state.push_constants[index];
+    //const auto& [_, current_constants] = state.push_constants[index];
 
-    int32_t slot_size = static_cast<int32_t>(current_constants.size());
+    int32_t slot_size = static_cast<int32_t>(state.get_root_table_size_at(index));
     int32_t slot = std::min(static_cast<int32_t>(group->getCBSlotIndex()), slot_size - 1);
     
-    if (slot_size <= 0)
+    if (slot <= 0)
         return false;
     
-    int32_t const_buffer_size = static_cast<int32_t>(current_constants.at(slot).size());
+    int32_t const_buffer_size = static_cast<int32_t>(state.get_root_table_entry_size_at(index, slot));
     
     if (const_buffer_size == 0)
         return false;
     
-    const vector<uint32_t>& buf = current_constants.at(slot);
+    const vector<uint32_t>* buf = state.get_constants_at(index, slot);//current_constants.at(slot);
 
-    unique_lock<shared_mutex>(groupBufferMutex);
+    if (buf != nullptr)
+    {
+        unique_lock<shared_mutex>(groupBufferMutex);
 
-    SetConstants(group, buf, cmd_list->get_device(), cmd_list);
-    ApplyConstantValues(devData.current_runtime, group, restVariables);
-    devData.constantsUpdated.insert(group);
+        SetConstants(group, *buf, cmd_list->get_device(), cmd_list);
+        ApplyConstantValues(devData.current_runtime, group, restVariables);
+        devData.constantsUpdated.insert(group);
+    }
 
     return true;
 }

--- a/src/DescriptorTracking.cpp
+++ b/src/DescriptorTracking.cpp
@@ -186,6 +186,7 @@ bool descriptor_tracking::on_update_descriptor_tables(device* device, uint32_t c
                 descriptor.view = static_cast<const resource_view*>(update.descriptors)[k];
                 break;
             case descriptor_type::constant_buffer:
+            case descriptor_type::shader_storage_buffer:
                 descriptor.constant = static_cast<const buffer_range*>(update.descriptors)[k];
             }
         }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -145,6 +145,10 @@ static void onResetCommandList(command_list* commandList)
     commandListData.Reset();
 }
 
+static bool onCreateSwapchain(swapchain_desc& desc, void* hwnd)
+{
+    return resourceManager.OnCreateSwapchain(desc, hwnd);
+}
 
 static void onInitSwapchain(reshade::api::swapchain* swapchain)
 {
@@ -163,6 +167,7 @@ static void onDestroySwapchain(reshade::api::swapchain* swapchain)
 static bool onCreateResource(device* device, resource_desc& desc, subresource_data* initial_data, resource_usage initial_state)
 {
     return resourceManager.OnCreateResource(device, desc, initial_data, initial_state);
+    return false;
 }
 
 
@@ -707,6 +712,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
         state_tracking::register_events(g_addonUIData.GetTrackDescriptors());
         Init();
 
+        reshade::register_event<reshade::addon_event::create_swapchain>(onCreateSwapchain);
         reshade::register_event<reshade::addon_event::init_swapchain>(onInitSwapchain);
         reshade::register_event<reshade::addon_event::destroy_swapchain>(onDestroySwapchain);
         reshade::register_event<reshade::addon_event::init_resource>(onInitResource);
@@ -745,6 +751,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD fdwReason, LPVOID)
         break;
     case DLL_PROCESS_DETACH:
         UnInit();
+        reshade::unregister_event<reshade::addon_event::create_swapchain>(onCreateSwapchain);
         reshade::unregister_event<reshade::addon_event::init_swapchain>(onInitSwapchain);
         reshade::unregister_event<reshade::addon_event::destroy_swapchain>(onDestroySwapchain);
         reshade::unregister_event<reshade::addon_event::reshade_present>(onReshadePresent);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -153,14 +153,12 @@ static bool onCreateSwapchain(swapchain_desc& desc, void* hwnd)
 static void onInitSwapchain(reshade::api::swapchain* swapchain)
 {
     resourceManager.OnInitSwapchain(swapchain);
-    renderingPreviewManager.OnInitSwapchain(swapchain);
 }
 
 
 static void onDestroySwapchain(reshade::api::swapchain* swapchain)
 {
     resourceManager.OnDestroySwapchain(swapchain);
-    renderingPreviewManager.OnDestroySwapchain(swapchain);
 }
 
 
@@ -265,6 +263,8 @@ static void onInitEffectRuntime(effect_runtime* runtime)
 {
     DeviceDataContainer& data = runtime->get_device()->get_private_data<DeviceDataContainer>();
 
+    renderingPreviewManager.OnInitSwapchain(runtime);
+
     // Dispose of texture bindings created from the runtime below
     if (data.current_runtime != nullptr)
     {
@@ -287,6 +287,9 @@ static void onInitEffectRuntime(effect_runtime* runtime)
 static void onDestroyEffectRuntime(effect_runtime* runtime)
 {
     DeviceDataContainer& data = runtime->get_device()->get_private_data<DeviceDataContainer>();
+
+
+    renderingPreviewManager.OnDestroySwapchain(runtime);
 
     // Remove runtime from stack
     for (auto it = runtimes.begin(); it != runtimes.end();)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -123,6 +123,7 @@ static void onInitDevice(device* device)
 static void onDestroyDevice(device* device)
 {
     resourceManager.OnDestroyDevice(device);
+    renderingPreviewManager.DestroyShaders(device);
 
     device->destroy_private_data<DeviceDataContainer>();
 }
@@ -263,7 +264,7 @@ static void onInitEffectRuntime(effect_runtime* runtime)
 {
     DeviceDataContainer& data = runtime->get_device()->get_private_data<DeviceDataContainer>();
 
-    renderingPreviewManager.OnInitSwapchain(runtime);
+    renderingPreviewManager.InitShaders(runtime->get_device());
 
     // Dispose of texture bindings created from the runtime below
     if (data.current_runtime != nullptr)
@@ -287,9 +288,6 @@ static void onInitEffectRuntime(effect_runtime* runtime)
 static void onDestroyEffectRuntime(effect_runtime* runtime)
 {
     DeviceDataContainer& data = runtime->get_device()->get_private_data<DeviceDataContainer>();
-
-
-    renderingPreviewManager.OnDestroySwapchain(runtime);
 
     // Remove runtime from stack
     for (auto it = runtimes.begin(); it != runtimes.end();)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -117,12 +117,14 @@ static uint32_t calculateShaderHash(void* shaderData)
 static void onInitDevice(device* device)
 {
     device->create_private_data<DeviceDataContainer>();
+    renderingPreviewManager.OnInitDevice(device);
 }
 
 
 static void onDestroyDevice(device* device)
 {
     resourceManager.OnDestroyDevice(device);
+    renderingPreviewManager.OnDestroyDevice(device);
 
     device->destroy_private_data<DeviceDataContainer>();
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -117,14 +117,12 @@ static uint32_t calculateShaderHash(void* shaderData)
 static void onInitDevice(device* device)
 {
     device->create_private_data<DeviceDataContainer>();
-    renderingPreviewManager.OnInitDevice(device);
 }
 
 
 static void onDestroyDevice(device* device)
 {
     resourceManager.OnDestroyDevice(device);
-    renderingPreviewManager.OnDestroyDevice(device);
 
     device->destroy_private_data<DeviceDataContainer>();
 }
@@ -151,12 +149,14 @@ static void onResetCommandList(command_list* commandList)
 static void onInitSwapchain(reshade::api::swapchain* swapchain)
 {
     resourceManager.OnInitSwapchain(swapchain);
+    renderingPreviewManager.OnInitSwapchain(swapchain);
 }
 
 
 static void onDestroySwapchain(reshade::api::swapchain* swapchain)
 {
     resourceManager.OnDestroySwapchain(swapchain);
+    renderingPreviewManager.OnDestroySwapchain(swapchain);
 }
 
 

--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -63,7 +63,8 @@ struct __declspec(novtable) TextureBindingData final
 
 struct __declspec(novtable) HuntPreview final
 {
-    reshade::api::resource_view target_rtv = reshade::api::resource_view{ 0 };
+    reshade::api::resource_view target_view = reshade::api::resource_view{ 0 };
+    bool is_srv = false;
     bool matched = false;
     uint64_t target_invocation_location = 0;
     uint32_t width = 0;
@@ -75,7 +76,8 @@ struct __declspec(novtable) HuntPreview final
     void Reset()
     {
         matched = false;
-        target_rtv = reshade::api::resource_view{ 0 };
+        is_srv = false;
+        target_view = reshade::api::resource_view{ 0 };
         target_invocation_location = 0;
         width = 0;
         height = 0;

--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -8,7 +8,7 @@
 #include "CDataFile.h"
 #include "ToggleGroup.h"
 
-using effect_queue = std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource_view>>;
+using effect_queue = std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>;
 
 struct __declspec(novtable) ShaderData final {
     uint32_t activeShaderHash = -1;
@@ -63,8 +63,7 @@ struct __declspec(novtable) TextureBindingData final
 
 struct __declspec(novtable) HuntPreview final
 {
-    reshade::api::resource_view target_view = reshade::api::resource_view{ 0 };
-    bool is_srv = false;
+    reshade::api::resource target = reshade::api::resource{ 0 };
     bool matched = false;
     uint64_t target_invocation_location = 0;
     uint32_t width = 0;
@@ -76,8 +75,7 @@ struct __declspec(novtable) HuntPreview final
     void Reset()
     {
         matched = false;
-        is_srv = false;
-        target_view = reshade::api::resource_view{ 0 };
+        target = reshade::api::resource{ 0 };
         target_invocation_location = 0;
         width = 0;
         height = 0;

--- a/src/RenderingBindingManager.cpp
+++ b/src/RenderingBindingManager.cpp
@@ -396,11 +396,19 @@ void RenderingBindingManager::ClearUnmatchedTextureBindings(reshade::api::comman
 
     if (!data.huntPreview.matched && uiData.GetToggleGroupIdShaderEditing() >= 0)
     {
-        resource_view rtv = resource_view{ 0 };
-        resourceManager.SetPreviewViewHandles(nullptr, &rtv, nullptr);
-        if (rtv != 0)
+        resource_view rtv_ping = resource_view{ 0 };
+        resource_view rtv_pong = resource_view{ 0 };
+
+        resourceManager.SetPingPreviewHandles(nullptr, &rtv_ping, nullptr);
+        resourceManager.SetPongPreviewHandles(nullptr, &rtv_pong, nullptr);
+
+        if (rtv_ping != 0)
         {
-            cmd_list->clear_render_target_view(rtv, clearColor);
+            cmd_list->clear_render_target_view(rtv_ping, clearColor);
+        }
+        if (rtv_pong != 0)
+        {
+            cmd_list->clear_render_target_view(rtv_pong, clearColor);
         }
     }
 }

--- a/src/RenderingBindingManager.cpp
+++ b/src/RenderingBindingManager.cpp
@@ -206,7 +206,7 @@ uint32_t RenderingBindingManager::UpdateTextureBinding(effect_runtime* runtime, 
 
 void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
     DeviceDataContainer& deviceData,
-    const unordered_map<string, tuple<ToggleGroup*, uint64_t, resource_view>>& bindingsToUpdate,
+    const unordered_map<string, tuple<ToggleGroup*, uint64_t, resource>>& bindingsToUpdate,
     vector<string>& removalList,
     const unordered_set<string>& toUpdateBindings)
 {
@@ -216,9 +216,9 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
         {
             effect_runtime* runtime = deviceData.current_runtime;
 
-            resource_view active_rtv = std::get<2>(bindingData);
+            resource active_resource = std::get<2>(bindingData);
 
-            if (active_rtv == 0)
+            if (active_resource == 0)
             {
                 continue;
             }
@@ -228,34 +228,28 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
             if (it != deviceData.bindingMap.end())
             {
                 auto& [bindingName, bindingData] = *it;
-                resource res = runtime->get_device()->get_resource_from_view(active_rtv);
-
-                if (res == 0)
-                {
-                    continue;
-                }
 
                 if (!bindingData.copy)
                 {
                     resource_view view_non_srgb = { 0 };
                     resource_view view_srgb = { 0 };
 
-                    resourceManager.SetShaderResourceViewHandles(res.handle, &view_non_srgb, &view_srgb);
+                    resourceManager.SetShaderResourceViewHandles(active_resource.handle, &view_non_srgb, &view_srgb);
 
                     if (view_non_srgb == 0)
                     {
                         return;
                     }
 
-                    resource_desc resDesc = runtime->get_device()->get_resource_desc(res);
+                    resource_desc resDesc = runtime->get_device()->get_resource_desc(active_resource);
 
                     resource target_res = bindingData.res;
 
-                    if (target_res != res)
+                    if (target_res != active_resource)
                     {
                         runtime->update_texture_bindings(bindingName.c_str(), view_non_srgb, view_srgb);
 
-                        bindingData.res = res;
+                        bindingData.res = active_resource;
                         bindingData.format = resDesc.texture.format;
                         bindingData.srv = view_non_srgb;
                         bindingData.width = resDesc.texture.width;
@@ -267,7 +261,7 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
                 }
                 else
                 {
-                    resource_desc resDesc = runtime->get_device()->get_resource_desc(res);
+                    resource_desc resDesc = runtime->get_device()->get_resource_desc(active_resource);
 
                     uint32_t retUpdate = UpdateTextureBinding(runtime, bindingName, resDesc);
 
@@ -275,7 +269,7 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
 
                     if (retUpdate && target_res != 0)
                     {
-                        cmd_list->copy_resource(res, target_res);
+                        cmd_list->copy_resource(active_resource, target_res);
                         bindingData.reset = false;
                     }
                 }

--- a/src/RenderingBindingManager.h
+++ b/src/RenderingBindingManager.h
@@ -27,7 +27,7 @@ namespace Rendering
 
         void _UpdateTextureBindings(reshade::api::command_list* cmd_list,
             DeviceDataContainer& deviceData,
-            const std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource_view>>& bindingsToUpdate,
+            const std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& bindingsToUpdate,
             std::vector<std::string>& removalList,
             const std::unordered_set<std::string>& toUpdateBindings);
         bool _CreateTextureBinding(reshade::api::effect_runtime* runtime,

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -54,7 +54,7 @@ bool RenderingEffectManager::RenderRemainingEffects(effect_runtime* runtime)
 bool RenderingEffectManager::_RenderEffects(
     command_list* cmd_list,
     DeviceDataContainer& deviceData,
-    const unordered_map<string, tuple<ToggleGroup*, uint64_t, resource_view>>& techniquesToRender,
+    const unordered_map<string, tuple<ToggleGroup*, uint64_t, resource>>& techniquesToRender,
     vector<string>& removalList,
     const unordered_set<string>& toRenderNames)
 {
@@ -70,19 +70,17 @@ bool RenderingEffectManager::_RenderEffects(
             if (tech != techniquesToRender.end() && !deviceData.allEnabledTechniques.at(name))
             {
                 auto& [techName, techData] = *tech;
-                const auto& [group, _, active_rtv] = techData;
+                const auto& [group, _, active_resource] = techData;
 
-                if (active_rtv == 0)
+                if (active_resource == 0)
                 {
                     return;
                 }
 
-                resource res = runtime->get_device()->get_resource_from_view(active_rtv);
+                resource_view view_non_srgb = {};
+                resource_view view_srgb = {};
 
-                resource_view view_non_srgb = active_rtv;
-                resource_view view_srgb = active_rtv;
-
-                resourceManager.SetResourceViewHandles(res.handle, &view_non_srgb, &view_srgb);
+                resourceManager.SetResourceViewHandles(active_resource.handle, &view_non_srgb, &view_srgb);
 
                 if (view_non_srgb == 0)
                 {
@@ -93,7 +91,7 @@ bool RenderingEffectManager::_RenderEffects(
 
                 runtime->render_technique(technique, cmd_list, view_non_srgb, view_srgb);
 
-                resource_desc resDesc = runtime->get_device()->get_resource_desc(res);
+                resource_desc resDesc = runtime->get_device()->get_resource_desc(active_resource);
                 removalList.push_back(name);
 
                 deviceData.allEnabledTechniques[name] = true;

--- a/src/RenderingEffectManager.h
+++ b/src/RenderingEffectManager.h
@@ -19,7 +19,7 @@ namespace Rendering
         bool _RenderEffects(
             reshade::api::command_list* cmd_list,
             DeviceDataContainer& deviceData,
-            const std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource_view>>& techniquesToRender,
+            const std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& techniquesToRender,
             std::vector<std::string>& removalList,
             const std::unordered_set<std::string>& toRenderNames);
     };

--- a/src/RenderingManager.cpp
+++ b/src/RenderingManager.cpp
@@ -120,7 +120,7 @@ const resource RenderingManager::GetCurrentResourceView(command_list* cmd_list, 
                 desc = std::min(++desc, desc_size - 1);
                 buf = state.get_descriptor_at(stageIndex, slot, desc);
 
-                while (buf != nullptr && buf->view == 0 && desc < desc_size - 2)
+                while ((buf == nullptr || buf->view == 0) && desc < desc_size - 2)
                 {
                     buf = state.get_descriptor_at(stageIndex, slot, ++desc);
                 }
@@ -128,9 +128,9 @@ const resource RenderingManager::GetCurrentResourceView(command_list* cmd_list, 
             else
             {
                 desc = desc > 0 ? --desc : 0;
-                buf = state.get_descriptor_at(stageIndex, slot, ++desc);
+                buf = state.get_descriptor_at(stageIndex, slot, desc);
 
-                while (buf != nullptr && buf->view == 0 && desc > 0)
+                while ((buf == nullptr || buf->view == 0) && desc > 0)
                 {
                     buf = state.get_descriptor_at(stageIndex, slot, --desc);
                 }

--- a/src/RenderingManager.cpp
+++ b/src/RenderingManager.cpp
@@ -97,7 +97,7 @@ const resource_view RenderingManager::GetCurrentResourceView(command_list* cmd_l
     if(action & MATCH_BINDING && group->getExtractResourceViews())
     {
         uint32_t stageIndex = std::min(static_cast<uint32_t>(2), group->getSRVShaderStage());
-        const auto& [_, current_srv] = state.descriptors[stageIndex];
+        const auto& [_, current_srv] = state.push_descriptors[stageIndex];
 
         int32_t slot_size = static_cast<uint32_t>(current_srv.size());
         int32_t slot = std::min(static_cast<int32_t>(group->getBindingSRVSlotIndex()), slot_size - 1);

--- a/src/RenderingManager.cpp
+++ b/src/RenderingManager.cpp
@@ -58,7 +58,7 @@ static inline bool IsColorBuffer(reshade::api::format value)
 }
 
 // Checks whether the aspect ratio of the two sets of dimensions is similar or not, stolen from ReShade's generic_depth addon
-static bool check_aspect_ratio(float width_to_check, float height_to_check, uint32_t width, uint32_t height, uint32_t matchingMode)
+bool RenderingManager::check_aspect_ratio(float width_to_check, float height_to_check, uint32_t width, uint32_t height, uint32_t matchingMode)
 {
     if (width_to_check == 0.0f || height_to_check == 0.0f)
         return true;
@@ -200,56 +200,6 @@ const resource_view RenderingManager::GetCurrentResourceView(command_list* cmd_l
                 !check_aspect_ratio(static_cast<float>(desc.texture.width), static_cast<float>(desc.texture.height), width, height, group->getMatchSwapchainResolution())) ||
                 (group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_RESOLUTION &&
                     (width != desc.texture.width || height != desc.texture.height)))
-            {
-                return active_rtv;
-            }
-        }
-
-        active_rtv = rtvs[index];
-    }
-
-    return active_rtv;
-}
-
-const resource_view RenderingManager::GetCurrentPreviewResourceView(command_list* cmd_list, DeviceDataContainer& deviceData, const ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action)
-{
-    resource_view active_rtv = { 0 };
-
-    if (deviceData.current_runtime == nullptr)
-    {
-        return active_rtv;
-    }
-
-    device* device = deviceData.current_runtime->get_device();
-
-    state_tracking& state = cmd_list->get_private_data<state_tracking>();
-    const vector<resource_view>& rtvs = state.render_targets;
-
-    size_t index = group->getRenderTargetIndex();
-    index = std::min(index, rtvs.size() - 1);
-
-    if (rtvs.size() > 0 && rtvs[index] != 0)
-    {
-        resource rs = device->get_resource_from_view(rtvs[index]);
-
-        if (rs == 0)
-        {
-            // Render targets may not have a resource bound in D3D12, in which case writes to them are discarded
-            return active_rtv;
-        }
-
-        // Don't apply effects to non-RGB buffers
-        resource_desc desc = device->get_resource_desc(rs);
-
-        // Make sure our target matches swap buffer dimensions when applying effects or it's explicitly requested
-        if (group->getMatchSwapchainResolution() < ShaderToggler::SWAPCHAIN_MATCH_MODE_NONE)
-        {
-            uint32_t width, height;
-            deviceData.current_runtime->get_screenshot_width_and_height(&width, &height);
-
-            if ((group->getMatchSwapchainResolution() >= ShaderToggler::SWAPCHAIN_MATCH_MODE_ASPECT_RATIO &&
-                !check_aspect_ratio(static_cast<float>(desc.texture.width), static_cast<float>(desc.texture.height), width, height, group->getMatchSwapchainResolution())) ||
-                (group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_RESOLUTION && (width != desc.texture.width || height != desc.texture.height)))
             {
                 return active_rtv;
             }

--- a/src/RenderingManager.h
+++ b/src/RenderingManager.h
@@ -59,8 +59,8 @@ namespace Rendering
     {
     public:
         static const reshade::api::resource_view GetCurrentResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
-        static const reshade::api::resource_view GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
-
+        static bool check_aspect_ratio(float width_to_check, float height_to_check, uint32_t width, uint32_t height, uint32_t matchingMode);
+        
         static void EnumerateTechniques(reshade::api::effect_runtime* runtime, std::function<void(reshade::api::effect_runtime*, reshade::api::effect_technique, std::string&)> func);
         static void QueueOrDequeue(
             reshade::api::command_list* cmd_list,

--- a/src/RenderingManager.h
+++ b/src/RenderingManager.h
@@ -58,7 +58,7 @@ namespace Rendering
     class __declspec(novtable) RenderingManager final
     {
     public:
-        static const reshade::api::resource_view GetCurrentResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
+        static const reshade::api::resource GetCurrentResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
         static bool check_aspect_ratio(float width_to_check, float height_to_check, uint32_t width, uint32_t height, uint32_t matchingMode);
         
         static void EnumerateTechniques(reshade::api::effect_runtime* runtime, std::function<void(reshade::api::effect_runtime*, reshade::api::effect_technique, std::string&)> func);
@@ -66,7 +66,7 @@ namespace Rendering
             reshade::api::command_list* cmd_list,
             DeviceDataContainer& deviceData,
             CommandListDataContainer& commandListData,
-            std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource_view>>& queue,
+            std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& queue,
             std::unordered_set<std::string>& immediateQueue,
             uint64_t callLocation,
             uint32_t layoutIndex,

--- a/src/RenderingPreviewManager.cpp
+++ b/src/RenderingPreviewManager.cpp
@@ -331,20 +331,20 @@ void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t cal
 
             if (previewResPong != 0 && (!group.getClearPreviewAlpha() || !supportsAlphaClear))
             {
-                resource resources[2] = { rs, previewResPong };
-                resource_usage from[2] = { rs_usage, resource_usage::shader_resource };
-                resource_usage to[2] = { resource_usage::copy_source, resource_usage::copy_dest };
-
+                //resource resources[2] = { rs, previewResPong };
+                //resource_usage from[2] = { rs_usage, resource_usage::shader_resource };
+                //resource_usage to[2] = { resource_usage::copy_source, resource_usage::copy_dest };
+                //
                 //cmd_list->barrier(2, resources, from, to);
                 cmd_list->copy_resource(rs, previewResPong);
                 //cmd_list->barrier(2, resources, to, from);
             }
             else if (previewResPing != 0 && previewResPong != 0 && preview_ping_srv != 0 && preview_pong_rtv != 0 && supportsAlphaClear)
             {
-                resource resources[2] = { rs, previewResPing };
-                resource_usage from[2] = { rs_usage, resource_usage::shader_resource };
-                resource_usage to[2] = { resource_usage::copy_source, resource_usage::copy_dest };
-
+                //resource resources[2] = { rs, previewResPing };
+                //resource_usage from[2] = { rs_usage, resource_usage::shader_resource };
+                //resource_usage to[2] = { resource_usage::copy_source, resource_usage::copy_dest };
+                //
                 //cmd_list->barrier(2, resources, from, to);
                 cmd_list->copy_resource(rs, previewResPing);
                 //cmd_list->barrier(2, resources, to, from);

--- a/src/RenderingPreviewManager.cpp
+++ b/src/RenderingPreviewManager.cpp
@@ -1,5 +1,6 @@
 #include "RenderingPreviewManager.h"
 #include "StateTracking.h"
+#include "resource.h"
 
 using namespace Rendering;
 using namespace ShaderToggler;
@@ -15,7 +16,131 @@ RenderingPreviewManager::~RenderingPreviewManager()
 
 }
 
+const resource_view RenderingPreviewManager::GetCurrentPreviewResourceView(command_list* cmd_list, DeviceDataContainer& deviceData, const ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action)
+{
+    resource_view active_rtv = { 0 };
 
+    if (deviceData.current_runtime == nullptr)
+    {
+        return active_rtv;
+    }
+
+    device* device = deviceData.current_runtime->get_device();
+
+    state_tracking& state = cmd_list->get_private_data<state_tracking>();
+    const vector<resource_view>& rtvs = state.render_targets;
+
+    size_t index = group->getRenderTargetIndex();
+    index = std::min(index, rtvs.size() - 1);
+
+    if (rtvs.size() > 0 && rtvs[index] != 0)
+    {
+        resource rs = device->get_resource_from_view(rtvs[index]);
+
+        if (rs == 0)
+        {
+            // Render targets may not have a resource bound in D3D12, in which case writes to them are discarded
+            return active_rtv;
+        }
+
+        // Don't apply effects to non-RGB buffers
+        resource_desc desc = device->get_resource_desc(rs);
+
+        // Make sure our target matches swap buffer dimensions when applying effects or it's explicitly requested
+        if (group->getMatchSwapchainResolution() < ShaderToggler::SWAPCHAIN_MATCH_MODE_NONE)
+        {
+            uint32_t width, height;
+            deviceData.current_runtime->get_screenshot_width_and_height(&width, &height);
+
+            if ((group->getMatchSwapchainResolution() >= ShaderToggler::SWAPCHAIN_MATCH_MODE_ASPECT_RATIO &&
+                !RenderingManager::check_aspect_ratio(static_cast<float>(desc.texture.width), static_cast<float>(desc.texture.height), width, height, group->getMatchSwapchainResolution())) ||
+                (group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_RESOLUTION && (width != desc.texture.width || height != desc.texture.height)))
+            {
+                return active_rtv;
+            }
+        }
+
+        if (group->getClearPreviewAlpha() && (device->get_api() == device_api::d3d10 || device->get_api() == device_api::d3d11 || device->get_api() == device_api::d3d12))
+        {
+            resourceManager.SetShaderResourceViewHandles(rs.handle, &active_rtv, nullptr);
+        }
+        else
+        {
+            active_rtv = rtvs[index];
+        }
+    }
+
+    return active_rtv;
+}
+
+void RenderingPreviewManager::OnInitDevice(reshade::api::device* device)
+{
+    // Create copy pipeline in order to omit alpha channel in preview. Only SM4.0 for now
+    if (device->get_api() == device_api::d3d10 || device->get_api() == device_api::d3d11 || device->get_api() == device_api::d3d12)
+    {
+        sampler_desc sampler_desc = {};
+        sampler_desc.filter = filter_mode::min_mag_mip_point;
+        sampler_desc.address_u = texture_address_mode::clamp;
+        sampler_desc.address_v = texture_address_mode::clamp;
+        sampler_desc.address_w = texture_address_mode::clamp;
+
+        pipeline_layout_param layout_params[2];
+        layout_params[0] = descriptor_range{ 0, 0, 0, 1, shader_stage::all, 1, descriptor_type::sampler };
+        layout_params[1] = descriptor_range{ 0, 0, 0, 1, shader_stage::all, 1, descriptor_type::shader_resource_view };
+
+        const EmbeddedResourceData vs = resourceManager.GetResourceData(SHADER_FULLSCREEN_VS_4_0);
+        const EmbeddedResourceData ps = resourceManager.GetResourceData(SHADER_PREVIEW_COPY_PS_4_0);
+
+        shader_desc vs_desc = { vs.data, vs.size };
+        shader_desc ps_desc = { ps.data, ps.size };
+
+        std::vector<pipeline_subobject> subobjects;
+        subobjects.push_back({ pipeline_subobject_type::vertex_shader, 1, &vs_desc });
+        subobjects.push_back({ pipeline_subobject_type::pixel_shader, 1, &ps_desc });
+
+        if (!device->create_pipeline_layout(2, layout_params, &copyPipelineLayout) ||
+            !device->create_pipeline(copyPipelineLayout, static_cast<uint32_t>(subobjects.size()), subobjects.data(), &copyPipeline) ||
+            !device->create_sampler(sampler_desc, &copyPipelineSampler))
+        {
+            reshade::log_message(reshade::log_level::warning, "Unable to create preview copy pipeline");
+        }
+    }
+}
+
+void RenderingPreviewManager::OnDestroyDevice(reshade::api::device* device)
+{
+    device->destroy_pipeline(copyPipeline);
+    device->destroy_pipeline_layout(copyPipelineLayout);
+    device->destroy_sampler(copyPipelineSampler);
+    copyPipeline = {};
+    copyPipelineLayout = {};
+    copyPipelineSampler = {};
+}
+
+void RenderingPreviewManager::CopyResource(command_list* cmd_list, resource_view srv_src, resource_view rtv_dst, uint32_t width, uint32_t height)
+{
+    device* device = cmd_list->get_device();
+    if (copyPipeline == 0 || !(device->get_api() == device_api::d3d10 || device->get_api() == device_api::d3d11 || device->get_api() == device_api::d3d12))
+    {
+        return;
+    }
+
+    cmd_list->bind_render_targets_and_depth_stencil(1, &rtv_dst);
+
+    cmd_list->bind_pipeline(pipeline_stage::all_graphics, copyPipeline);
+
+    cmd_list->push_descriptors(shader_stage::pixel, copyPipelineLayout, 0, descriptor_table_update{ {}, 0, 0, 1, descriptor_type::sampler, &copyPipelineSampler });
+    cmd_list->push_descriptors(shader_stage::pixel, copyPipelineLayout, 1, descriptor_table_update{ {}, 0, 0, 1, descriptor_type::shader_resource_view, &srv_src });
+
+    const viewport viewport = { 0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f };
+    cmd_list->bind_viewports(0, 1, &viewport);
+    const rect scissor_rect = { 0, 0, static_cast<int32_t>(width), static_cast<int32_t>(height) };
+    cmd_list->bind_scissor_rects(0, 1, &scissor_rect);
+
+    cmd_list->draw(3, 1, 0, 0);
+
+    cmd_list->get_private_data<state_tracking>().apply(cmd_list);
+}
 
 void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t callLocation, uint64_t invocation)
 {
@@ -44,15 +169,15 @@ void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t cal
 
         if (invocation & MATCH_PREVIEW_PS)
         {
-            active_rtv = RenderingManager::GetCurrentPreviewResourceView(cmd_list, deviceData, &group, commandListData, 0, invocation & MATCH_PREVIEW_PS);
+            active_rtv = GetCurrentPreviewResourceView(cmd_list, deviceData, &group, commandListData, 0, invocation & MATCH_PREVIEW_PS);
         }
         else if (invocation & MATCH_PREVIEW_VS)
         {
-            active_rtv = RenderingManager::GetCurrentPreviewResourceView(cmd_list, deviceData, &group, commandListData, 1, invocation & MATCH_PREVIEW_VS);
+            active_rtv = GetCurrentPreviewResourceView(cmd_list, deviceData, &group, commandListData, 1, invocation & MATCH_PREVIEW_VS);
         }
         else if (invocation & MATCH_PREVIEW_CS)
         {
-            active_rtv = RenderingManager::GetCurrentPreviewResourceView(cmd_list, deviceData, &group, commandListData, 2, invocation & MATCH_PREVIEW_CS);
+            active_rtv = GetCurrentPreviewResourceView(cmd_list, deviceData, &group, commandListData, 2, invocation & MATCH_PREVIEW_CS);
         }
 
         if (active_rtv != 0)
@@ -93,11 +218,16 @@ void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t cal
         else
         {
             resource previewRes = resource{ 0 };
-            resourceManager.SetPreviewViewHandles(&previewRes, nullptr, nullptr);
+            resource_view preview_rtv = resource_view{ 0 };
+            resourceManager.SetPreviewViewHandles(&previewRes, &preview_rtv, nullptr);
 
-            if (previewRes != 0)
+            if (previewRes != 0 && !group.getClearPreviewAlpha())
             {
                 cmd_list->copy_resource(rs, previewRes);
+            }
+            else if (previewRes != 0 && preview_rtv != 0 && group.getClearPreviewAlpha() && (device->get_api() == device_api::d3d10 || device->get_api() == device_api::d3d11 || device->get_api() == device_api::d3d12))
+            {
+                CopyResource(cmd_list, deviceData.huntPreview.target_rtv, preview_rtv, deviceData.huntPreview.width, deviceData.huntPreview.height);
             }
         }
 

--- a/src/RenderingPreviewManager.cpp
+++ b/src/RenderingPreviewManager.cpp
@@ -308,7 +308,7 @@ void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t cal
         }
         else
         {
-            bool supportsAlphaClear = device->get_api() == device_api::d3d9 || device->get_api() == device_api::d3d10 || device->get_api() == device_api::d3d11 || device->get_api() == device_api::d3d12;
+            bool supportsAlphaClear = device->get_api() == device_api::d3d9 || device->get_api() == device_api::d3d10 || device->get_api() == device_api::d3d11/* || device->get_api() == device_api::d3d12*/;
 
             resource previewResPing = resource{ 0 };
             resource previewResPong = resource{ 0 };

--- a/src/RenderingPreviewManager.h
+++ b/src/RenderingPreviewManager.h
@@ -14,7 +14,7 @@ namespace Rendering
         void OnDestroySwapchain(reshade::api::swapchain* swapchain);
         void CopyResource(reshade::api::command_list* cmd_list, reshade::api::resource_view srv_src, reshade::api::resource_view rtv_dst, uint32_t width, uint32_t height);
         void UpdatePreview(reshade::api::command_list* cmd_list, uint64_t callLocation, uint64_t invocation);
-        const std::tuple<reshade::api::resource_view, bool> GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
+        const reshade::api::resource_view GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
 
     private:
         AddonImGui::AddonUIData& uiData;
@@ -23,5 +23,6 @@ namespace Rendering
         reshade::api::pipeline copyPipeline;
         reshade::api::pipeline_layout copyPipelineLayout;
         reshade::api::sampler copyPipelineSampler;
+        reshade::api::resource vertexBuffer = {};
     };
 }

--- a/src/RenderingPreviewManager.h
+++ b/src/RenderingPreviewManager.h
@@ -14,16 +14,26 @@ namespace Rendering
         void DestroyShaders(reshade::api::device* device);
         void CopyResource(reshade::api::command_list* cmd_list, reshade::api::resource_view srv_src, reshade::api::resource_view rtv_dst, uint32_t width, uint32_t height);
         void UpdatePreview(reshade::api::command_list* cmd_list, uint64_t callLocation, uint64_t invocation);
-        const reshade::api::resource_view GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
+        const reshade::api::resource GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
 
     private:
+        struct vert_uv
+        {
+            float x, y;
+        };
+
+        struct vert_input
+        {
+            vert_uv uv;
+        };
+
         AddonImGui::AddonUIData& uiData;
         ResourceManager& resourceManager;
 
         reshade::api::pipeline copyPipeline;
         reshade::api::pipeline_layout copyPipelineLayout;
         reshade::api::sampler copyPipelineSampler;
-        reshade::api::resource vertexBuffer = {};
+        reshade::api::resource fullscreenQuadVertexBuffer = {};
         bool pipelineDestroyed = false;
     };
 }

--- a/src/RenderingPreviewManager.h
+++ b/src/RenderingPreviewManager.h
@@ -14,7 +14,7 @@ namespace Rendering
         void OnDestroyDevice(reshade::api::device* device);
         void CopyResource(reshade::api::command_list* cmd_list, reshade::api::resource_view srv_src, reshade::api::resource_view rtv_dst, uint32_t width, uint32_t height);
         void UpdatePreview(reshade::api::command_list* cmd_list, uint64_t callLocation, uint64_t invocation);
-        const reshade::api::resource_view GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
+        const std::tuple<reshade::api::resource_view, bool> GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
 
     private:
         AddonImGui::AddonUIData& uiData;

--- a/src/RenderingPreviewManager.h
+++ b/src/RenderingPreviewManager.h
@@ -10,8 +10,8 @@ namespace Rendering
         RenderingPreviewManager(AddonImGui::AddonUIData& data, ResourceManager& rManager);
         ~RenderingPreviewManager();
 
-        void OnInitDevice(reshade::api::device* device);
-        void OnDestroyDevice(reshade::api::device* device);
+        void OnInitSwapchain(reshade::api::swapchain* swapchain);
+        void OnDestroySwapchain(reshade::api::swapchain* swapchain);
         void CopyResource(reshade::api::command_list* cmd_list, reshade::api::resource_view srv_src, reshade::api::resource_view rtv_dst, uint32_t width, uint32_t height);
         void UpdatePreview(reshade::api::command_list* cmd_list, uint64_t callLocation, uint64_t invocation);
         const std::tuple<reshade::api::resource_view, bool> GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);

--- a/src/RenderingPreviewManager.h
+++ b/src/RenderingPreviewManager.h
@@ -10,9 +10,18 @@ namespace Rendering
         RenderingPreviewManager(AddonImGui::AddonUIData& data, ResourceManager& rManager);
         ~RenderingPreviewManager();
 
+        void OnInitDevice(reshade::api::device* device);
+        void OnDestroyDevice(reshade::api::device* device);
+        void CopyResource(reshade::api::command_list* cmd_list, reshade::api::resource_view srv_src, reshade::api::resource_view rtv_dst, uint32_t width, uint32_t height);
         void UpdatePreview(reshade::api::command_list* cmd_list, uint64_t callLocation, uint64_t invocation);
+        const reshade::api::resource_view GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
+
     private:
         AddonImGui::AddonUIData& uiData;
         ResourceManager& resourceManager;
+
+        reshade::api::pipeline copyPipeline;
+        reshade::api::pipeline_layout copyPipelineLayout;
+        reshade::api::sampler copyPipelineSampler;
     };
 }

--- a/src/RenderingPreviewManager.h
+++ b/src/RenderingPreviewManager.h
@@ -10,8 +10,8 @@ namespace Rendering
         RenderingPreviewManager(AddonImGui::AddonUIData& data, ResourceManager& rManager);
         ~RenderingPreviewManager();
 
-        void OnInitSwapchain(reshade::api::swapchain* swapchain);
-        void OnDestroySwapchain(reshade::api::swapchain* swapchain);
+        void InitShaders(reshade::api::device* device);
+        void DestroyShaders(reshade::api::device* device);
         void CopyResource(reshade::api::command_list* cmd_list, reshade::api::resource_view srv_src, reshade::api::resource_view rtv_dst, uint32_t width, uint32_t height);
         void UpdatePreview(reshade::api::command_list* cmd_list, uint64_t callLocation, uint64_t invocation);
         const reshade::api::resource_view GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
@@ -24,5 +24,6 @@ namespace Rendering
         reshade::api::pipeline_layout copyPipelineLayout;
         reshade::api::sampler copyPipelineSampler;
         reshade::api::resource vertexBuffer = {};
+        bool pipelineDestroyed = false;
     };
 }

--- a/src/RenderingQueueManager.cpp
+++ b/src/RenderingQueueManager.cpp
@@ -56,12 +56,12 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
                     {
                         if (!group->getCopyTextureBinding() || group->getExtractResourceViews())
                         {
-                            sData.bindingsToUpdate.emplace(group->getTextureBindingName(), std::make_tuple(group, CALL_DRAW, resource_view{ 0 }));
+                            sData.bindingsToUpdate.emplace(group->getTextureBindingName(), std::make_tuple(group, CALL_DRAW, resource{ 0 }));
                             queue_mask |= (match_binding << CALL_DRAW * MATCH_DELIMITER);
                         }
                         else
                         {
-                            sData.bindingsToUpdate.emplace(group->getTextureBindingName(), std::make_tuple(group, group->getBindingInvocationLocation(), resource_view{ 0 }));
+                            sData.bindingsToUpdate.emplace(group->getTextureBindingName(), std::make_tuple(group, group->getBindingInvocationLocation(), resource{ 0 }));
                             queue_mask |= (match_binding << (group->getBindingInvocationLocation() * MATCH_DELIMITER)) | (match_binding << (CALL_DRAW * MATCH_DELIMITER));
                         }
                     }
@@ -80,7 +80,7 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
                         {
                             if (!sData.techniquesToRender.contains(techName))
                             {
-                                sData.techniquesToRender.emplace(techName, std::make_tuple(group, group->getInvocationLocation(), resource_view{ 0 }));
+                                sData.techniquesToRender.emplace(techName, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
                                 queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
                             }
                         }
@@ -93,7 +93,7 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
                         {
                             if (!sData.techniquesToRender.contains(techName))
                             {
-                                sData.techniquesToRender.emplace(techName, std::make_tuple(group, group->getInvocationLocation(), resource_view{ 0 }));
+                                sData.techniquesToRender.emplace(techName, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
                                 queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
                             }
                         }
@@ -139,13 +139,13 @@ void RenderingQueueManager::_RescheduleGroups(ShaderData& sData, CommandListData
     for (const auto& tech : sData.techniquesToRender)
     {
         const ToggleGroup* group = std::get<0>(tech.second);
-        const resource_view view = std::get<2>(tech.second);
+        const resource res = std::get<2>(tech.second);
 
-        if (view == 0 && group->getRequeueAfterRTMatchingFailure())
+        if (res == 0 && group->getRequeueAfterRTMatchingFailure())
         {
             queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
 
-            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target_view == 0)
+            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target == 0)
             {
                 if (uiData.GetCurrentTabType() == AddonImGui::TAB_RENDER_TARGET)
                 {
@@ -160,13 +160,13 @@ void RenderingQueueManager::_RescheduleGroups(ShaderData& sData, CommandListData
     for (const auto& tech : sData.bindingsToUpdate)
     {
         const ToggleGroup* group = std::get<0>(tech.second);
-        const resource_view view = std::get<2>(tech.second);
+        const resource res = std::get<2>(tech.second);
 
-        if (view == 0 && group->getRequeueAfterRTMatchingFailure())
+        if (res == 0 && group->getRequeueAfterRTMatchingFailure())
         {
             queue_mask |= (match_binding << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_binding << (CALL_DRAW * MATCH_DELIMITER));
 
-            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target_view == 0)
+            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target == 0)
             {
                 if (uiData.GetCurrentTabType() == AddonImGui::TAB_RENDER_TARGET)
                 {

--- a/src/RenderingQueueManager.cpp
+++ b/src/RenderingQueueManager.cpp
@@ -145,7 +145,7 @@ void RenderingQueueManager::_RescheduleGroups(ShaderData& sData, CommandListData
         {
             queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
 
-            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target_rtv == 0)
+            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target_view == 0)
             {
                 if (uiData.GetCurrentTabType() == AddonImGui::TAB_RENDER_TARGET)
                 {
@@ -166,7 +166,7 @@ void RenderingQueueManager::_RescheduleGroups(ShaderData& sData, CommandListData
         {
             queue_mask |= (match_binding << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_binding << (CALL_DRAW * MATCH_DELIMITER));
 
-            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target_rtv == 0)
+            if (group->getId() == uiData.GetToggleGroupIdShaderEditing() && !deviceData.huntPreview.matched && deviceData.huntPreview.target_view == 0)
             {
                 if (uiData.GetCurrentTabType() == AddonImGui::TAB_RENDER_TARGET)
                 {

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -137,24 +137,22 @@ void ResourceManager::CreateViews(reshade::api::device* device, reshade::api::re
 
             if (static_cast<uint32_t>(rdesc.usage & resource_usage::render_target))
             {
-                if (device->create_resource_view(resource, resource_usage::render_target,
-                    resource_view_desc(format_non_srgb), &view_non_srgb) ||
-                    device->create_resource_view(resource, resource_usage::render_target,
-                        resource_view_desc(format_srgb), &view_srgb))
-                {
-                    s_sRGBResourceViews.emplace(resource.handle, make_pair(view_non_srgb, view_srgb));
-                }
+                device->create_resource_view(resource, resource_usage::render_target,
+                    resource_view_desc(format_non_srgb), &view_non_srgb);
+                device->create_resource_view(resource, resource_usage::render_target,
+                    resource_view_desc(format_srgb), &view_srgb);
+
+                s_sRGBResourceViews.emplace(resource.handle, make_pair(view_non_srgb, view_srgb));
             }
 
             if (static_cast<uint32_t>(rdesc.usage & resource_usage::shader_resource))
             {
-                if (device->create_resource_view(resource, resource_usage::shader_resource,
-                    resource_view_desc(format_non_srgb), &srv_non_srgb) ||
-                    device->create_resource_view(resource, resource_usage::shader_resource,
-                        resource_view_desc(format_srgb), &srv_srgb))
-                {
-                    s_SRVs.emplace(resource.handle, make_pair(srv_non_srgb, srv_srgb));
-                }
+                device->create_resource_view(resource, resource_usage::shader_resource,
+                    resource_view_desc(format_non_srgb), &srv_non_srgb);
+                device->create_resource_view(resource, resource_usage::shader_resource,
+                    resource_view_desc(format_srgb), &srv_srgb);
+
+                s_SRVs.emplace(resource.handle, make_pair(srv_non_srgb, srv_srgb));
             }
         }
 

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -56,7 +56,8 @@ namespace Rendering
 
         void DisposePreview(reshade::api::effect_runtime* runtime);
         void CheckPreview(reshade::api::command_list* cmd_list, reshade::api::device* device, reshade::api::effect_runtime* runtime);
-        void SetPreviewViewHandles(reshade::api::resource* res, reshade::api::resource_view* rtv, reshade::api::resource_view* srv);
+        void SetPingPreviewHandles(reshade::api::resource* res, reshade::api::resource_view* rtv, reshade::api::resource_view* srv);
+        void SetPongPreviewHandles(reshade::api::resource* res, reshade::api::resource_view* rtv, reshade::api::resource_view* srv);
         bool IsCompatibleWithPreviewFormat(reshade::api::effect_runtime* runtime, reshade::api::resource res);
 
         static EmbeddedResourceData GetResourceData(uint16_t id);
@@ -75,8 +76,8 @@ namespace Rendering
         std::shared_mutex resource_mutex;
         std::shared_mutex view_mutex;
 
-        reshade::api::resource preview_res;
-        reshade::api::resource_view preview_rtv;
-        reshade::api::resource_view preview_srv;
+        reshade::api::resource preview_res[2];
+        reshade::api::resource_view preview_rtv[2];
+        reshade::api::resource_view preview_srv[2];
     };
 }

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -48,7 +48,6 @@ namespace Rendering
         void OnDestroySwapchain(reshade::api::swapchain* swapchain);
         void OnDestroyDevice(reshade::api::device*);
 
-        void DisposeView(reshade::api::device* device, uint64_t handle);
         void SetResourceViewHandles(uint64_t handle, reshade::api::resource_view* non_srgb_view, reshade::api::resource_view* srgb_view);
         void SetShaderResourceViewHandles(uint64_t handle, reshade::api::resource_view* non_srgb_view, reshade::api::resource_view* srgb_view);
         void SetResourceShim(const std::string& shim) { _shimType = ResolveResourceShimType(shim); }
@@ -62,6 +61,8 @@ namespace Rendering
 
         static EmbeddedResourceData GetResourceData(uint16_t id);
     private:
+        void DisposeView(reshade::api::device* device, uint64_t handle);
+        void CreateViews(reshade::api::device* device, reshade::api::resource res);
         static ResourceShimType ResolveResourceShimType(const std::string&);
 
         ResourceShimType _shimType = ResourceShimType::Resource_Shim_None;
@@ -71,7 +72,7 @@ namespace Rendering
         std::unordered_map<uint64_t, std::pair<reshade::api::resource_view, reshade::api::resource_view>> s_SRVs;
 
         std::unordered_map<uint64_t, uint32_t> _resourceViewRefCount;
-        std::unordered_map<uint64_t, uint64_t> _resourceViewRef;
+        std::unordered_map<uint64_t, uint64_t> _resourceViewToResource;
 
         std::shared_mutex resource_mutex;
         std::shared_mutex view_mutex;

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -25,6 +25,12 @@ namespace Rendering
         "ffxiv"
     };
 
+    struct EmbeddedResourceData
+    {
+        const void* data;
+        size_t size;
+    };
+
     class __declspec(novtable) ResourceManager final
     {
     public:
@@ -52,6 +58,8 @@ namespace Rendering
         void CheckPreview(reshade::api::command_list* cmd_list, reshade::api::device* device, reshade::api::effect_runtime* runtime);
         void SetPreviewViewHandles(reshade::api::resource* res, reshade::api::resource_view* rtv, reshade::api::resource_view* srv);
         bool IsCompatibleWithPreviewFormat(reshade::api::effect_runtime* runtime, reshade::api::resource res);
+
+        static EmbeddedResourceData GetResourceData(uint16_t id);
     private:
         static ResourceShimType ResolveResourceShimType(const std::string&);
 

--- a/src/ShaderToggler.rc
+++ b/src/ShaderToggler.rc
@@ -115,6 +115,10 @@ SHADER_FULLSCREEN_VS_4_0 RCDATA                  "shader\\fullscreen_vs_4_0.cso"
 
 SHADER_PREVIEW_COPY_PS_4_0 RCDATA                  "shader\\preview_copy_ps_4_0.cso"
 
+SHADER_FULLSCREEN_VS_3_0 RCDATA                  "shader\\fullscreen_vs_3_0.cso"
+
+SHADER_PREVIEW_COPY_PS_3_0 RCDATA                  "shader\\preview_copy_ps_3_0.cso"
+
 #endif    // English (United Kingdom) resources
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/ShaderToggler.rc
+++ b/src/ShaderToggler.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,3,2,592
- PRODUCTVERSION 1,3,2,592
+ FILEVERSION 1,3,3,592
+ PRODUCTVERSION 1,3,3,592
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "alex"
             VALUE "FileDescription", "ReshadeEffectShaderToggler Addon for ReShade 5.9+"
-            VALUE "FileVersion", "1.3.2.592"
+            VALUE "FileVersion", "1.3.3.592"
             VALUE "InternalName", "ShaderTo.dll"
             VALUE "LegalCopyright", "Copyright (C) 2022 Frans Bouma, Copyright (C) 2023 alex"
             VALUE "OriginalFilename", "ShaderTo.dll"
             VALUE "ProductName", "Reshade Effect Shader Toggler addon for ReShade 5.9+"
-            VALUE "ProductVersion", "1.3.2.592"
+            VALUE "ProductVersion", "1.3.3.592"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/ShaderToggler.rc
+++ b/src/ShaderToggler.rc
@@ -111,6 +111,10 @@ LICENSE_REST            RCDATA                  "..\\LICENSE"
 
 LICENSE_IMGUI           RCDATA                  "..\\deps\\reshade\\deps\\imgui\\LICENSE.txt"
 
+SHADER_FULLSCREEN_VS_4_0 RCDATA                  "shader\\fullscreen_vs_4_0.cso"
+
+SHADER_PREVIEW_COPY_PS_4_0 RCDATA                  "shader\\preview_copy_ps_4_0.cso"
+
 #endif    // English (United Kingdom) resources
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/ShaderToggler.vcxproj
+++ b/src/ShaderToggler.vcxproj
@@ -249,6 +249,20 @@
     <ResourceCompile Include="ShaderToggler.rc" />
   </ItemGroup>
   <ItemGroup>
+    <FxCompile Include="shader\fullscreen_vs_3_0.hlsl">
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">3.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">3.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">3.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">3.0</ShaderModel>
+    </FxCompile>
     <FxCompile Include="shader\fullscreen_vs_4_0.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
@@ -262,6 +276,20 @@
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+    </FxCompile>
+    <FxCompile Include="shader\preview_copy_ps_3_0.hlsl">
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">3.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">3.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">3.0</ShaderModel>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">3.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
     </FxCompile>
     <FxCompile Include="shader\preview_copy_ps_4_0.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>

--- a/src/ShaderToggler.vcxproj
+++ b/src/ShaderToggler.vcxproj
@@ -258,6 +258,10 @@
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
     </FxCompile>
     <FxCompile Include="shader\preview_copy_ps_4_0.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
@@ -268,6 +272,10 @@
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
+      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)shader\%(Filename).cso</ObjectFileOutput>
     </FxCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/ShaderToggler.vcxproj
+++ b/src/ShaderToggler.vcxproj
@@ -248,6 +248,28 @@
   <ItemGroup>
     <ResourceCompile Include="ShaderToggler.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <FxCompile Include="shader\fullscreen_vs_4_0.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Vertex</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+    </FxCompile>
+    <FxCompile Include="shader\preview_copy_ps_4_0.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+    </FxCompile>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/src/ShaderToggler.vcxproj.filters
+++ b/src/ShaderToggler.vcxproj.filters
@@ -210,5 +210,11 @@
     <FxCompile Include="shader\preview_copy_ps_4_0.hlsl">
       <Filter>Source Files\Shader</Filter>
     </FxCompile>
+    <FxCompile Include="shader\preview_copy_ps_3_0.hlsl">
+      <Filter>Source Files\Shader</Filter>
+    </FxCompile>
+    <FxCompile Include="shader\fullscreen_vs_3_0.hlsl">
+      <Filter>Source Files\Shader</Filter>
+    </FxCompile>
   </ItemGroup>
 </Project>

--- a/src/ShaderToggler.vcxproj.filters
+++ b/src/ShaderToggler.vcxproj.filters
@@ -13,6 +13,9 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Source Files\Shader">
+      <UniqueIdentifier>{49cedbdd-c6fe-44f1-aefd-6a322eef7207}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="crc32_hash.hpp">
@@ -199,5 +202,13 @@
     <ResourceCompile Include="ShaderToggler.rc">
       <Filter>Resource Files</Filter>
     </ResourceCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <FxCompile Include="shader\fullscreen_vs_4_0.hlsl">
+      <Filter>Source Files\Shader</Filter>
+    </FxCompile>
+    <FxCompile Include="shader\preview_copy_ps_4_0.hlsl">
+      <Filter>Source Files\Shader</Filter>
+    </FxCompile>
   </ItemGroup>
 </Project>

--- a/src/StateTracking.cpp
+++ b/src/StateTracking.cpp
@@ -17,8 +17,8 @@ void state_block::apply_descriptors_dx12_vulkan(command_list* cmd_list) const
     for (uint32_t stageIdx = 0; stageIdx < ALL_SHADER_STAGES_SIZE; stageIdx++)
     {
         auto& descriptor_data = cmd_list->get_device()->get_private_data<descriptor_tracking>();
-        const auto& [pipelinelayout, descriptor_set] = descriptor_tables[stageIdx];
-        shader_stage stages = descriptor_tables_stages[stageIdx];
+        const auto& [pipelinelayout, root_table] = root_tables[stageIdx];
+        shader_stage stages = root_table_stages[stageIdx];
 
         if ((static_cast<uint32_t>(stages) | shader_stages_set) <= shader_stages_set)
         {
@@ -26,91 +26,64 @@ void state_block::apply_descriptors_dx12_vulkan(command_list* cmd_list) const
         }
 
         shader_stages_set |= static_cast<uint32_t>(stages);
-        uint32_t start_index = 0;
-        uint32_t end_index = 0;
-
-        // Restore descriptor tables
-        while (end_index < descriptor_set.size() && start_index < descriptor_set.size())
-        {
-            while (start_index < descriptor_set.size() && (descriptor_data.get_pipeline_layout_param(pipelinelayout, start_index).type != pipeline_layout_param_type::descriptor_table || descriptor_set[start_index].handle == 0))
-            {
-                start_index++;
-            }
-
-            end_index = start_index;
-
-            while (end_index < descriptor_set.size() && descriptor_data.get_pipeline_layout_param(pipelinelayout, end_index).type == pipeline_layout_param_type::descriptor_table && descriptor_set[end_index].handle != 0)
-            {
-                end_index++;
-            }
-
-            cmd_list->bind_descriptor_tables(stages, pipelinelayout, start_index, end_index - start_index, &descriptor_set.data()[start_index]);
-
-            start_index = end_index;
-        }
 
         // Restore root signature
-        if (descriptor_set.size() == 0 && pipelinelayout != 0)
+        if (root_table.size() == 0 && pipelinelayout != 0)
         {
             cmd_list->bind_descriptor_tables(stages, pipelinelayout, 0, 0, nullptr);
         }
 
-        // Restore push descriptors
-        const auto& pushes = push_descriptors[stageIdx].second;
-
-        for (uint32_t i = 0; i < pushes.size(); i++)
+        // Restore descriptors
+        for (uint32_t i = 0; i < root_table.size(); i++)
         {
-            if (descriptor_data.get_pipeline_layout_param(pipelinelayout, i).type != pipeline_layout_param_type::push_descriptors || pushes[i].size() == 0)
+            if (descriptor_data.get_pipeline_layout_param(pipelinelayout, i).type == pipeline_layout_param_type::descriptor_table && root_table[i].descriptor_table.handle != 0)
             {
-                continue;
+                cmd_list->bind_descriptor_tables(stages, pipelinelayout, i, 1, &root_table[i].descriptor_table);
             }
-            switch (pushes[i][0].type)
+            else if (descriptor_data.get_pipeline_layout_param(pipelinelayout, i).type == pipeline_layout_param_type::push_descriptors && root_table[i].buffer_index >= 0 && descriptor_buffer[root_table[i].buffer_index].size() > 0)
             {
-            case descriptor_type::sampler:
-                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].sampler });
-                break;
-            case descriptor_type::sampler_with_resource_view:
-                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].sampler_and_view });
-                break;
-            case descriptor_type::shader_resource_view:
-            case descriptor_type::unordered_access_view:
-                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].view });
-                break;
-            case descriptor_type::constant_buffer:
-            case descriptor_type::shader_storage_buffer:
-                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].constant });
+                const auto& descriptor = descriptor_buffer[root_table[i].buffer_index][0];
+
+                switch (descriptor.type)
+                {
+                case descriptor_type::sampler:
+                    cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, descriptor.type, &descriptor.sampler });
+                    break;
+                case descriptor_type::sampler_with_resource_view:
+                    cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, descriptor.type, &descriptor.sampler_and_view });
+                    break;
+                case descriptor_type::shader_resource_view:
+                case descriptor_type::unordered_access_view:
+                    cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, descriptor.type, &descriptor.view });
+                    break;
+                case descriptor_type::constant_buffer:
+                case descriptor_type::shader_storage_buffer:
+                    cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, descriptor.type, &descriptor.constant });
+                }
             }
-        }
-
-        // Restore push constants
-        const auto& constants = push_constants[stageIdx].second;
-
-        for (uint32_t i = 0; i < constants.size(); i++)
-        {
-            if (descriptor_data.get_pipeline_layout_param(pipelinelayout, i).type != pipeline_layout_param_type::push_descriptors || constants[i].size() == 0)
+            else if (descriptor_data.get_pipeline_layout_param(pipelinelayout, i).type == pipeline_layout_param_type::push_constants && root_table[i].buffer_index >= 0 && constant_buffer[root_table[i].buffer_index].size() > 0)
             {
-                continue;
+                cmd_list->push_constants(stages, pipelinelayout, i, 0, static_cast<uint32_t>(constant_buffer[root_table[i].buffer_index].size()), constant_buffer[root_table[i].buffer_index].data());
             }
-
-            cmd_list->push_constants(stages, pipelinelayout, i, 0, static_cast<uint32_t>(constants[i].size()), constants[i].data());
         }
     }
 }
 
 void state_block::apply_descriptors(command_list* cmd_list) const
 {
-    // Restores descriptors potentially overwritten by our preview copy pipeline
-    auto& [desc_layout, descriptors] = cmd_list->get_private_data<state_tracking>().push_descriptors[0];
+    auto& [desc_layout, descriptors] = cmd_list->get_private_data<state_tracking>().root_tables[0];
 
-    std::array<descriptor_tracking::descriptor_data*, 2> copyDescriptors;
+    std::array<const descriptor_tracking::descriptor_data*, 2> copyDescriptors;
 
-    if (descriptors.size() > 0 && descriptors[0].size() > 0)
-        copyDescriptors[0] = &descriptors[0][0];
+    // first sampler
+    if (descriptors.size() > 0 && descriptor_buffer[descriptors[0].buffer_index].size() > 0)
+        copyDescriptors[0] = &descriptor_buffer[descriptors[0].buffer_index][0];
     else
         copyDescriptors[0] = nullptr;
 
-    if (descriptors.size() > 1 && descriptors[1].size() > 0)
-        copyDescriptors[1] = &descriptors[1][0];
+    // first shader resource view
+    if (descriptors.size() > 1 && descriptor_buffer[descriptors[1].buffer_index].size() > 0)
+        copyDescriptors[1] = &descriptor_buffer[descriptors[1].buffer_index][0];
     else
         copyDescriptors[1] = nullptr;
 
@@ -140,9 +113,9 @@ void state_block::apply_descriptors(command_list* cmd_list) const
     }
 }
 
-void state_block::capture(command_list* cmd_list)
+void state_block::capture(command_list* cmd_list, bool force_restore)
 {
-    if (cmd_list->get_device()->get_api() == device_api::d3d9 && dx_state == nullptr)
+    if (force_restore && cmd_list->get_device()->get_api() == device_api::d3d9 && dx_state == nullptr)
     {
         IDirect3DDevice9* device = reinterpret_cast<IDirect3DDevice9*>(cmd_list->get_device()->get_native());
 
@@ -153,20 +126,25 @@ void state_block::capture(command_list* cmd_list)
     }
 }
 
-void state_block::apply(command_list* cmd_list)
+void state_block::apply(command_list* cmd_list, bool force_restore)
 {
     switch (cmd_list->get_device()->get_api())
     {
     case device_api::d3d9:
-        apply_dx9(cmd_list);
+        apply_dx9(cmd_list, force_restore);
         break;
     default:
-        apply_default(cmd_list);
+        apply_default(cmd_list, force_restore);
     }
 }
 
-void state_block::apply_dx9(reshade::api::command_list* cmd_list)
+void state_block::apply_dx9(reshade::api::command_list* cmd_list, bool force_restore)
 {
+    if (!force_restore)
+    {
+        return;
+    }
+
     // ???
     if (!render_targets.empty() || depth_stencil != 0)
         cmd_list->bind_render_targets_and_depth_stencil(static_cast<uint32_t>(render_targets.size()), render_targets.data(), depth_stencil);
@@ -178,12 +156,15 @@ void state_block::apply_dx9(reshade::api::command_list* cmd_list)
         dx_state = nullptr;
     }
 }
-void state_block::apply_dx12_vulkan(reshade::api::command_list* cmd_list) const
-{
-}
 
-void state_block::apply_default(reshade::api::command_list* cmd_list) const
+void state_block::apply_default(reshade::api::command_list* cmd_list, bool force_restore) const
 {
+    // For dx12 and vulkan, always force full state restoration
+    if (!force_restore && cmd_list->get_device()->get_api() != device_api::d3d12 && cmd_list->get_device()->get_api() != device_api::vulkan)
+    {
+        return;
+    }
+
     if (!render_targets.empty() || depth_stencil != 0)
         cmd_list->bind_render_targets_and_depth_stencil(static_cast<uint32_t>(render_targets.size()), render_targets.data(), depth_stencil);
 
@@ -237,10 +218,10 @@ void state_block::clear()
     sample_mask = 0xFFFFFFFF;
     viewports.clear();
     scissor_rects.clear();
-    descriptor_tables.fill(make_pair(pipeline_layout{ 0 }, std::vector<descriptor_table>()));
-    descriptor_tables_stages.fill(static_cast<shader_stage>(0));
-    push_constants.fill(make_pair(pipeline_layout{ 0 }, std::vector<std::vector<uint32_t>>()));
-    push_descriptors.fill(make_pair(pipeline_layout{ 0 }, std::vector<std::vector<descriptor_tracking::descriptor_data>>()));
+    root_tables.fill(make_pair(pipeline_layout{ 0 }, std::vector<root_entry>()));
+    root_table_stages.fill(static_cast<shader_stage>(0));
+    constant_buffer.clear();
+    descriptor_buffer.clear();
     current_pipeline.fill(pipeline{ 0 });
     current_pipeline_stage.fill(static_cast<pipeline_stage>(0));
     resource_barrier_track.clear();
@@ -356,69 +337,69 @@ static void on_bind_scissor_rects(command_list* cmd_list, uint32_t first, uint32
 
 static void on_bind_descriptor_tables(command_list* cmd_list, shader_stage stages, pipeline_layout layout, uint32_t first, uint32_t count, const descriptor_table* tables)
 {
-    int32_t idx = get_shader_stage_index(stages);
-
-    if (idx < 0)
-        return;
-
-    auto& state_tracker = cmd_list->get_private_data<state_tracking>();
-    auto& state = state_tracker.descriptor_tables[idx];
-    auto& state_stages = state_tracker.descriptor_tables_stages[idx];
-    auto& [desc_layout, push_descriptors] = state_tracker.push_descriptors[idx];
-    auto& [_, push_constants] = state_tracker.push_constants[idx];
-    const auto& descriptor_state = cmd_list->get_device()->get_private_data<descriptor_tracking>();
-
-    if (layout != state.first)
-    {
-        state.second.clear(); // Layout changed, which resets all descriptor set bindings
-        push_constants.clear();
-        //clear_descriptors(descriptors);
-        push_descriptors.clear();
-    }
-
-    state.first = layout;
-    desc_layout = layout;
-    state_stages = stages;
-
-    if (state.second.size() < (first + count))
-        state.second.resize(first + count);
-
-    if (push_descriptors.size() < first + count)
-        push_descriptors.resize(first + count);
-
-    for (uint32_t i = 0; i < count; ++i)
-    {
-        state.second[i + first] = tables[i];
-
-        const pipeline_layout_param param = descriptor_state.get_pipeline_layout_param(layout, first + i);
-        if (param.type != pipeline_layout_param_type::descriptor_table)
-            continue;
-
-        uint32_t max_descriptor_size = 0;
-        for (uint32_t k = 0; k < param.descriptor_table.count; ++k)
-        {
-            const descriptor_range& range = param.descriptor_table.ranges[k];
-            if (range.count != UINT32_MAX && range.type != descriptor_type::sampler)
-                max_descriptor_size = std::max(max_descriptor_size, range.binding + range.count);
-        }
-
-        if (push_descriptors[first + i].size() < max_descriptor_size)
-            push_descriptors[first + i].resize(max_descriptor_size);
-
-        for (uint32_t k = 0; k < param.descriptor_table.count; ++k)
-        {
-            const descriptor_range& range = param.descriptor_table.ranges[k];
-
-            if (range.count == UINT32_MAX || range.type == descriptor_type::sampler)
-                continue; // Skip unbounded ranges
-
-            uint32_t base_offset = 0;
-            descriptor_heap heap = { 0 };
-            cmd_list->get_device()->get_descriptor_heap_offset(tables[i], range.binding, 0, &heap, &base_offset);
-
-            descriptor_state.set_all_descriptors(heap, base_offset, range.count, push_descriptors[first + i], range.binding);
-        }
-    }
+    //int32_t idx = get_shader_stage_index(stages);
+    //
+    //if (idx < 0)
+    //    return;
+    //
+    //auto& state_tracker = cmd_list->get_private_data<state_tracking>();
+    //auto& state = state_tracker.descriptor_tables[idx];
+    //auto& state_stages = state_tracker.descriptor_tables_stages[idx];
+    //auto& [desc_layout, push_descriptors] = state_tracker.push_descriptors[idx];
+    //auto& [_, push_constants] = state_tracker.push_constants[idx];
+    //const auto& descriptor_state = cmd_list->get_device()->get_private_data<descriptor_tracking>();
+    //
+    //if (layout != state.first)
+    //{
+    //    state.second.clear(); // Layout changed, which resets all descriptor set bindings
+    //    push_constants.clear();
+    //    //clear_descriptors(descriptors);
+    //    push_descriptors.clear();
+    //}
+    //
+    //state.first = layout;
+    //desc_layout = layout;
+    //state_stages = stages;
+    //
+    //if (state.second.size() < (first + count))
+    //    state.second.resize(first + count);
+    //
+    //if (push_descriptors.size() < first + count)
+    //    push_descriptors.resize(first + count);
+    //
+    //for (uint32_t i = 0; i < count; ++i)
+    //{
+    //    state.second[i + first] = tables[i];
+    //
+    //    const pipeline_layout_param param = descriptor_state.get_pipeline_layout_param(layout, first + i);
+    //    if (param.type != pipeline_layout_param_type::descriptor_table)
+    //        continue;
+    //
+    //    uint32_t max_descriptor_size = 0;
+    //    for (uint32_t k = 0; k < param.descriptor_table.count; ++k)
+    //    {
+    //        const descriptor_range& range = param.descriptor_table.ranges[k];
+    //        if (range.count != UINT32_MAX && range.type != descriptor_type::sampler)
+    //            max_descriptor_size = std::max(max_descriptor_size, range.binding + range.count);
+    //    }
+    //
+    //    if (push_descriptors[first + i].size() < max_descriptor_size)
+    //        push_descriptors[first + i].resize(max_descriptor_size);
+    //
+    //    for (uint32_t k = 0; k < param.descriptor_table.count; ++k)
+    //    {
+    //        const descriptor_range& range = param.descriptor_table.ranges[k];
+    //
+    //        if (range.count == UINT32_MAX || range.type == descriptor_type::sampler)
+    //            continue; // Skip unbounded ranges
+    //
+    //        uint32_t base_offset = 0;
+    //        descriptor_heap heap = { 0 };
+    //        cmd_list->get_device()->get_descriptor_heap_offset(tables[i], range.binding, 0, &heap, &base_offset);
+    //
+    //        descriptor_state.set_all_descriptors(heap, base_offset, range.count, push_descriptors[first + i], range.binding);
+    //    }
+    //}
 }
 
 static void on_bind_descriptor_tables_no_track(command_list* cmd_list, shader_stage stages, pipeline_layout layout, uint32_t first, uint32_t count, const descriptor_table* tables)
@@ -429,56 +410,35 @@ static void on_bind_descriptor_tables_no_track(command_list* cmd_list, shader_st
         return;
 
     auto& state_tracker = cmd_list->get_private_data<state_tracking>();
-    auto& [tables_layout, descriptor_tables] = state_tracker.descriptor_tables[idx];
-    auto& state_stages = state_tracker.descriptor_tables_stages[idx];
-    auto& [push_layout, push_descriptors] = state_tracker.push_descriptors[idx];
-    auto& [const_layout, push_constants] = state_tracker.push_constants[idx];
+    auto& [desc_layout, root_table] = state_tracker.root_tables[idx];
+    auto& state_stages = state_tracker.root_table_stages[idx];
+    auto& constant_buffer = state_tracker.constant_buffer;
+    auto& descriptor_buffer = state_tracker.descriptor_buffer;
 
-    if (layout != tables_layout)
+    if (desc_layout != layout)
     {
-        descriptor_tables.clear(); // Layout changed, which resets all descriptor set bindings
-        push_constants.clear();
-        push_descriptors.clear();
+        root_table.clear(); // Layout changed, which resets all descriptor set bindings
+        constant_buffer.clear();
+        descriptor_buffer.clear();
     }
 
-    tables_layout = layout;
-    push_layout = layout;
-    const_layout = layout;
+    desc_layout = layout;
     state_stages = stages;
 
-    if (descriptor_tables.size() < (first + count))
-        descriptor_tables.resize(first + count);
+    if (root_table.size() < (first + count))
+        root_table.resize(first + count);
 
     for (uint32_t i = 0; i < count; ++i)
     {
-        descriptor_tables[i + first] = tables[i];
+        root_table[i + first] = tables[i];
     }
 }
 
-static void on_push_descriptors(command_list* cmd_list, shader_stage stages, pipeline_layout layout, uint32_t layout_param, const descriptor_table_update& update)
+static inline void fill_descriptors(std::vector<descriptor_tracking::descriptor_data>& table, const descriptor_table_update& update)
 {
-    int32_t idx = get_shader_stage_index(stages);
-
-    if (idx < 0)
-        return;
-
-    auto& [desc_layout, descriptors] = cmd_list->get_private_data<state_tracking>().push_descriptors[idx];
-
-    desc_layout = layout;
-
-    if (descriptors.size() < layout_param + 1)
-    {
-        descriptors.resize(layout_param + 1);
-    }
-
-    if (descriptors[layout_param].size() < update.binding + update.count)
-    {
-        descriptors[layout_param].resize(update.binding + update.count);
-    }
-
     for (uint32_t i = 0; i < update.count; i++)
     {
-        descriptor_tracking::descriptor_data& descriptor = descriptors[layout_param][update.binding + i];
+        descriptor_tracking::descriptor_data& descriptor = table[update.binding + i];
 
         descriptor.type = update.type;
 
@@ -503,6 +463,59 @@ static void on_push_descriptors(command_list* cmd_list, shader_stage stages, pip
     }
 }
 
+static void on_push_descriptors(command_list* cmd_list, shader_stage stages, pipeline_layout layout, uint32_t layout_param, const descriptor_table_update& update)
+{
+    int32_t idx = get_shader_stage_index(stages);
+
+    if (idx < 0)
+        return;
+
+    auto& state_tracker = cmd_list->get_private_data<state_tracking>();
+    auto& [desc_layout, root_table] = state_tracker.root_tables[idx];
+    auto& state_stages = state_tracker.root_table_stages[idx];
+    auto& constant_buffer = state_tracker.constant_buffer;
+    auto& descriptor_buffer = state_tracker.descriptor_buffer;
+
+    if (desc_layout != layout)
+    {
+        root_table.clear(); // Layout changed, which resets all descriptor set bindings
+        constant_buffer.clear();
+        descriptor_buffer.clear();
+    }
+
+    desc_layout = layout;
+    state_stages = stages;
+
+    if (root_table.size() < layout_param + 1)
+    {
+        root_table.resize(layout_param + 1);
+    }
+
+    auto& root_table_entry = root_table[layout_param];
+
+    // Initialize table for descriptors
+    if (root_table_entry.type == root_entry_type::undefined)
+    {
+        std::vector<descriptor_tracking::descriptor_data> buf(update.binding + update.count);
+
+        fill_descriptors(buf, update);
+
+        descriptor_buffer.push_back(std::move(buf));
+        root_table_entry = { root_entry_type::push_descriptors, static_cast<int32_t>(descriptor_buffer.size()) - 1, {} };
+    }
+    else
+    {
+        auto& buf = descriptor_buffer[root_table_entry.buffer_index];
+
+        if (buf.size() < update.binding + update.count)
+        {
+            buf.resize(update.binding + update.count);
+        }
+
+        fill_descriptors(buf, update);
+    }
+}
+
 static void on_push_constants(command_list* cmd_list, shader_stage stages, pipeline_layout layout, uint32_t layout_param, uint32_t first, uint32_t count, const void* values)
 {
     int32_t idx = get_shader_stage_index(stages);
@@ -510,24 +523,117 @@ static void on_push_constants(command_list* cmd_list, shader_stage stages, pipel
     if (idx < 0)
         return;
 
-    auto& [desc_layout, constants] = cmd_list->get_private_data<state_tracking>().push_constants[idx];
+    auto& state_tracker = cmd_list->get_private_data<state_tracking>();
+    auto& [desc_layout, root_table] = state_tracker.root_tables[idx];
+    auto& state_stages = state_tracker.root_table_stages[idx];
+    auto& constant_buffer = state_tracker.constant_buffer;
+    auto& descriptor_buffer = state_tracker.descriptor_buffer;
+
+    if (desc_layout != layout)
+    {
+        root_table.clear(); // Layout changed, which resets all descriptor set bindings
+        constant_buffer.clear();
+        descriptor_buffer.clear();
+    }
 
     desc_layout = layout;
+    state_stages = stages;
 
-    if (constants.size() < layout_param + 1)
+    if (root_table.size() < layout_param + 1)
     {
-        constants.resize(layout_param + 1);
+        root_table.resize(layout_param + 1);
     }
 
-    if (constants[layout_param].size() < first + count)
+    auto& root_table_entry = root_table[layout_param];
+
+    // Not buffered yet, initialize
+    if (root_table_entry.type == root_entry_type::undefined)
     {
-        constants[layout_param].resize(first + count);
+        std::vector<uint32_t> buf(first + count);
+
+        for (uint32_t i = 0; i < count; i++)
+        {
+            buf[first + i] = reinterpret_cast<const uint32_t*>(values)[i];
+        }
+
+        constant_buffer.push_back(std::move(buf));
+
+        root_table_entry = { root_entry_type::push_constants, static_cast<int32_t>(constant_buffer.size()) - 1, {} };
+    }
+    else // Write to existing buffer index
+    {
+        auto& buf = constant_buffer[root_table_entry.buffer_index];
+
+        if (buf.size() < first + count)
+        {
+            buf.resize(first + count);
+        }
+
+        for (uint32_t i = 0; i < count; i++)
+        {
+            buf[first + i] = reinterpret_cast<const uint32_t*>(values)[i];
+        }
+    }
+}
+
+const descriptor_tracking::descriptor_data* state_block::get_descriptor_at(uint32_t stageIndex, uint32_t layout_param, uint32_t binding) const
+{
+    if (root_tables[stageIndex].second.size() > layout_param)
+    {
+        const auto& root_entry = root_tables[stageIndex].second[layout_param];
+
+        if ((root_entry.type == root_entry_type::push_descriptors || root_entry.type == root_entry_type::descriptor_table) && root_entry.buffer_index >= 0)
+        {
+            const auto& table_entry = descriptor_buffer[root_entry.buffer_index];
+
+            if (table_entry.size() > binding)
+            {
+                return &table_entry[binding];
+            }
+        }
     }
 
-    for (uint32_t i = 0; i < count; i++)
+    return nullptr;
+}
+
+
+const size_t state_block::get_root_table_entry_size_at(uint32_t stageIndex, uint32_t layout_param) const
+{
+    if (root_tables[stageIndex].second.size() > layout_param)
     {
-        constants[layout_param][first + i] = reinterpret_cast<const uint32_t*>(values)[i];
+        const auto& root_entry = root_tables[stageIndex].second[layout_param];
+
+        if ((root_entry.type == root_entry_type::push_descriptors || root_entry.type == root_entry_type::descriptor_table) && root_entry.buffer_index >= 0)
+        {
+            return descriptor_buffer[root_entry.buffer_index].size();
+        }
+        else if (root_entry.type == root_entry_type::push_constants && root_entry.buffer_index >= 0)
+        {
+            return constant_buffer[root_entry.buffer_index].size();
+        }
     }
+
+    return 0;
+}
+
+const size_t state_block::get_root_table_size_at(uint32_t stageIndex) const
+{
+    return root_tables[stageIndex].second.size();
+}
+
+const std::vector<uint32_t>* state_block::get_constants_at(uint32_t stageIndex, uint32_t layout_param) const
+{
+    if (root_tables[stageIndex].second.size() > layout_param)
+    {
+        const auto& root_entry = root_tables[stageIndex].second[layout_param];
+
+        if (root_entry.type == root_entry_type::push_constants && root_entry.buffer_index >= 0)
+        {
+            return &constant_buffer.at(root_entry.buffer_index);
+        }
+    }
+
+    return {};
 }
 
 static void on_reset_command_list(command_list* cmd_list)
@@ -595,6 +701,9 @@ static void on_barrier(command_list* cmd_list, uint32_t count, const resource* r
 
 void state_tracking::register_events(bool track)
 {
+    // disable for now
+    track = false;
+
     track_descriptors = track;
     descriptor_tracking::register_events(track);
 

--- a/src/StateTracking.cpp
+++ b/src/StateTracking.cpp
@@ -28,11 +28,11 @@ void state_block::apply_descriptors_dx12_vulkan(command_list* cmd_list) const
         shader_stages_set |= static_cast<uint32_t>(stages);
 
         // Restore root signature
-        if (root_table.size() == 0 && pipelinelayout != 0)
+        if (pipelinelayout != 0)
         {
             // Check if root signature has any tables bound, restore if not
             const auto& containsTables = std::find_if(root_table.begin(), root_table.end(), [](const root_entry& entry) { return entry.descriptor_table.handle != 0; });
-            if (containsTables != root_table.end())
+            if (containsTables == root_table.end())
                 cmd_list->bind_descriptor_tables(stages, pipelinelayout, 0, 0, nullptr);
         }
 

--- a/src/StateTracking.cpp
+++ b/src/StateTracking.cpp
@@ -11,33 +11,8 @@ using namespace StateTracking;
 
 bool state_tracking::track_descriptors = true;
 
-void state_block::apply(command_list* cmd_list) const
+void state_block::apply_descriptors_dx12_vulkan(command_list* cmd_list) const
 {
-    if (!render_targets.empty() || depth_stencil != 0)
-        cmd_list->bind_render_targets_and_depth_stencil(static_cast<uint32_t>(render_targets.size()), render_targets.data(), depth_stencil);
-
-    uint32_t pipeline_stages_set = 0;
-    for (uint32_t s = 0; s < ALL_PIPELINE_STAGES_SIZE; s++)
-    {
-        if ((static_cast<uint32_t>(current_pipeline_stage[s]) | pipeline_stages_set) > pipeline_stages_set)
-        {
-            pipeline_stages_set |= static_cast<uint32_t>(current_pipeline_stage[s]);
-            cmd_list->bind_pipeline(current_pipeline_stage[s], current_pipeline[s]);
-        }
-    }
-
-    if (primitive_topology != primitive_topology::undefined)
-        cmd_list->bind_pipeline_state(dynamic_state::primitive_topology, static_cast<uint32_t>(primitive_topology));
-    if (blend_constant != 0)
-        cmd_list->bind_pipeline_state(dynamic_state::blend_constant, blend_constant);
-    if (front_stencil_reference_value != 0)
-        cmd_list->bind_pipeline_state(dynamic_state::front_stencil_reference_value, front_stencil_reference_value);
-
-    if (!viewports.empty())
-        cmd_list->bind_viewports(0, static_cast<uint32_t>(viewports.size()), viewports.data());
-    if (!scissor_rects.empty())
-        cmd_list->bind_scissor_rects(0, static_cast<uint32_t>(scissor_rects.size()), scissor_rects.data());
-
     uint32_t shader_stages_set = 0;
     for (uint32_t stageIdx = 0; stageIdx < ALL_SHADER_STAGES_SIZE; stageIdx++)
     {
@@ -51,20 +26,20 @@ void state_block::apply(command_list* cmd_list) const
         }
 
         shader_stages_set |= static_cast<uint32_t>(stages);
-        bool done = false;
         uint32_t start_index = 0;
         uint32_t end_index = 0;
 
+        // Restore descriptor tables
         while (end_index < descriptor_set.size() && start_index < descriptor_set.size())
         {
-            while (start_index < descriptor_set.size() && (descriptor_data.get_pipeline_layout_param(pipelinelayout, start_index).type == pipeline_layout_param_type::push_constants || descriptor_set[start_index].handle == 0))
+            while (start_index < descriptor_set.size() && (descriptor_data.get_pipeline_layout_param(pipelinelayout, start_index).type != pipeline_layout_param_type::descriptor_table || descriptor_set[start_index].handle == 0))
             {
                 start_index++;
             }
 
             end_index = start_index;
 
-            while (end_index < descriptor_set.size() && descriptor_data.get_pipeline_layout_param(pipelinelayout, end_index).type != pipeline_layout_param_type::push_constants && descriptor_set[end_index].handle != 0)
+            while (end_index < descriptor_set.size() && descriptor_data.get_pipeline_layout_param(pipelinelayout, end_index).type == pipeline_layout_param_type::descriptor_table && descriptor_set[end_index].handle != 0)
             {
                 end_index++;
             }
@@ -73,11 +48,59 @@ void state_block::apply(command_list* cmd_list) const
 
             start_index = end_index;
         }
-    }
 
+        // Restore root signature
+        if (descriptor_set.size() == 0 && pipelinelayout != 0)
+        {
+            cmd_list->bind_descriptor_tables(stages, pipelinelayout, 0, 0, nullptr);
+        }
+
+        // Restore push descriptors
+        const auto& pushes = push_descriptors[stageIdx].second;
+
+        for (uint32_t i = 0; i < pushes.size(); i++)
+        {
+            if (descriptor_data.get_pipeline_layout_param(pipelinelayout, i).type != pipeline_layout_param_type::push_descriptors || pushes[i].size() == 0)
+            {
+                continue;
+            }
+            switch (pushes[i][0].type)
+            {
+            case descriptor_type::sampler:
+                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].sampler });
+                break;
+            case descriptor_type::sampler_with_resource_view:
+                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].sampler_and_view });
+                break;
+            case descriptor_type::shader_resource_view:
+            case descriptor_type::unordered_access_view:
+                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].view });
+                break;
+            case descriptor_type::constant_buffer:
+            case descriptor_type::shader_storage_buffer:
+                cmd_list->push_descriptors(stages, pipelinelayout, i, descriptor_table_update{ {}, 0, 0, 1, pushes[i][0].type, &pushes[i][0].constant });
+            }
+        }
+
+        // Restore push constants
+        const auto& constants = push_constants[stageIdx].second;
+
+        for (uint32_t i = 0; i < constants.size(); i++)
+        {
+            if (descriptor_data.get_pipeline_layout_param(pipelinelayout, i).type != pipeline_layout_param_type::push_descriptors || constants[i].size() == 0)
+            {
+                continue;
+            }
+
+            cmd_list->push_constants(stages, pipelinelayout, i, 0, static_cast<uint32_t>(constants[i].size()), constants[i].data());
+        }
+    }
+}
+
+void state_block::apply_descriptors(command_list* cmd_list) const
+{
     // Restores descriptors potentially overwritten by our preview copy pipeline
-    // TODO: check how this works for DX12
-    auto& [desc_layout, descriptors] = cmd_list->get_private_data<state_tracking>().descriptors[0];
+    auto& [desc_layout, descriptors] = cmd_list->get_private_data<state_tracking>().push_descriptors[0];
 
     std::array<descriptor_tracking::descriptor_data*, 2> copyDescriptors;
 
@@ -95,7 +118,7 @@ void state_block::apply(command_list* cmd_list) const
     {
         if (copyDescriptors[i] == nullptr)
             continue;
-    
+
         switch (copyDescriptors[i]->type)
         {
         case descriptor_type::sampler:
@@ -117,6 +140,91 @@ void state_block::apply(command_list* cmd_list) const
     }
 }
 
+void state_block::capture(command_list* cmd_list)
+{
+    if (cmd_list->get_device()->get_api() == device_api::d3d9 && dx_state == nullptr)
+    {
+        IDirect3DDevice9* device = reinterpret_cast<IDirect3DDevice9*>(cmd_list->get_device()->get_native());
+
+        if (SUCCEEDED(device->CreateStateBlock(D3DSBT_ALL, &dx_state)))
+        {
+            dx_state->Capture();
+        }
+    }
+}
+
+void state_block::apply(command_list* cmd_list)
+{
+    switch (cmd_list->get_device()->get_api())
+    {
+    case device_api::d3d9:
+        apply_dx9(cmd_list);
+        break;
+    default:
+        apply_default(cmd_list);
+    }
+}
+
+void state_block::apply_dx9(reshade::api::command_list* cmd_list)
+{
+    // ???
+    if (!render_targets.empty() || depth_stencil != 0)
+        cmd_list->bind_render_targets_and_depth_stencil(static_cast<uint32_t>(render_targets.size()), render_targets.data(), depth_stencil);
+
+    if (dx_state != nullptr)
+    {
+        dx_state->Apply();
+        dx_state->Release();
+        dx_state = nullptr;
+    }
+}
+void state_block::apply_dx12_vulkan(reshade::api::command_list* cmd_list) const
+{
+}
+
+void state_block::apply_default(reshade::api::command_list* cmd_list) const
+{
+    if (!render_targets.empty() || depth_stencil != 0)
+        cmd_list->bind_render_targets_and_depth_stencil(static_cast<uint32_t>(render_targets.size()), render_targets.data(), depth_stencil);
+
+    uint32_t pipeline_stages_set = 0;
+    for (uint32_t s = 0; s < ALL_PIPELINE_STAGES_SIZE; s++)
+    {
+        if ((static_cast<uint32_t>(current_pipeline_stage[s]) | pipeline_stages_set) > pipeline_stages_set)
+        {
+            pipeline_stages_set |= static_cast<uint32_t>(current_pipeline_stage[s]);
+            cmd_list->bind_pipeline(current_pipeline_stage[s], current_pipeline[s]);
+        }
+    }
+
+    if (primitive_topology != primitive_topology::undefined)
+        cmd_list->bind_pipeline_state(dynamic_state::primitive_topology, static_cast<uint32_t>(primitive_topology));
+    if (blend_constant != 0)
+        cmd_list->bind_pipeline_state(dynamic_state::blend_constant, blend_constant);
+    if (sample_mask != 0xFFFFFFFF)
+        cmd_list->bind_pipeline_state(dynamic_state::sample_mask, sample_mask);
+    if (srgb_write_enable != 0)
+        cmd_list->bind_pipeline_state(dynamic_state::srgb_write_enable, srgb_write_enable);
+    if (front_stencil_reference_value != 0)
+        cmd_list->bind_pipeline_state(dynamic_state::front_stencil_reference_value, front_stencil_reference_value);
+    if (back_stencil_reference_value != 0)
+        cmd_list->bind_pipeline_state(dynamic_state::back_stencil_reference_value, back_stencil_reference_value);
+
+    if (!viewports.empty())
+        cmd_list->bind_viewports(0, static_cast<uint32_t>(viewports.size()), viewports.data());
+    if (!scissor_rects.empty())
+        cmd_list->bind_scissor_rects(0, static_cast<uint32_t>(scissor_rects.size()), scissor_rects.data());
+
+    if (cmd_list->get_device()->get_api() == device_api::d3d12 || cmd_list->get_device()->get_api() == device_api::vulkan)
+    {
+        apply_descriptors_dx12_vulkan(cmd_list);
+    }
+    else
+    {
+        apply_descriptors(cmd_list);
+    }
+}
+
 void state_block::clear()
 {
     render_targets.clear();
@@ -125,14 +233,17 @@ void state_block::clear()
     blend_constant = 0;
     front_stencil_reference_value = 0;
     back_stencil_reference_value = 0;
+    srgb_write_enable = 0;
+    sample_mask = 0xFFFFFFFF;
     viewports.clear();
     scissor_rects.clear();
     descriptor_tables.fill(make_pair(pipeline_layout{ 0 }, std::vector<descriptor_table>()));
     descriptor_tables_stages.fill(static_cast<shader_stage>(0));
     push_constants.fill(make_pair(pipeline_layout{ 0 }, std::vector<std::vector<uint32_t>>()));
-    descriptors.fill(make_pair(pipeline_layout{ 0 }, std::vector<std::vector<descriptor_tracking::descriptor_data>>()));
+    push_descriptors.fill(make_pair(pipeline_layout{ 0 }, std::vector<std::vector<descriptor_tracking::descriptor_data>>()));
     current_pipeline.fill(pipeline{ 0 });
     current_pipeline_stage.fill(static_cast<pipeline_stage>(0));
+    resource_barrier_track.clear();
 }
 
 static inline int32_t get_shader_stage_index(shader_stage stages)
@@ -211,6 +322,12 @@ static void on_bind_pipeline_states(command_list* cmd_list, uint32_t count, cons
         case dynamic_state::back_stencil_reference_value:
             state.back_stencil_reference_value = values[i];
             break;
+        case dynamic_state::sample_mask:
+            state.sample_mask = values[i];
+            break;
+        case dynamic_state::srgb_write_enable:
+            state.srgb_write_enable = values[i];
+            break;
         }
     }
 }
@@ -237,21 +354,6 @@ static void on_bind_scissor_rects(command_list* cmd_list, uint32_t first, uint32
         state.scissor_rects[i + first] = rects[i];
 }
 
-static void clear_descriptors(std::vector<std::vector<descriptor_tracking::descriptor_data>>& desc)
-{
-    for (auto& i : desc)
-    {
-        for (auto& j : i)
-        {
-            j.constant.buffer = { 0 };
-            j.view = { 0 };
-            j.sampler = { 0 };
-            j.sampler_and_view.sampler = { 0 };
-            j.sampler_and_view.view = { 0 };
-        }
-    }
-}
-
 static void on_bind_descriptor_tables(command_list* cmd_list, shader_stage stages, pipeline_layout layout, uint32_t first, uint32_t count, const descriptor_table* tables)
 {
     int32_t idx = get_shader_stage_index(stages);
@@ -262,7 +364,7 @@ static void on_bind_descriptor_tables(command_list* cmd_list, shader_stage stage
     auto& state_tracker = cmd_list->get_private_data<state_tracking>();
     auto& state = state_tracker.descriptor_tables[idx];
     auto& state_stages = state_tracker.descriptor_tables_stages[idx];
-    auto& [desc_layout, descriptors] = state_tracker.descriptors[idx];
+    auto& [desc_layout, push_descriptors] = state_tracker.push_descriptors[idx];
     auto& [_, push_constants] = state_tracker.push_constants[idx];
     const auto& descriptor_state = cmd_list->get_device()->get_private_data<descriptor_tracking>();
 
@@ -270,7 +372,8 @@ static void on_bind_descriptor_tables(command_list* cmd_list, shader_stage stage
     {
         state.second.clear(); // Layout changed, which resets all descriptor set bindings
         push_constants.clear();
-        clear_descriptors(descriptors);
+        //clear_descriptors(descriptors);
+        push_descriptors.clear();
     }
 
     state.first = layout;
@@ -280,8 +383,8 @@ static void on_bind_descriptor_tables(command_list* cmd_list, shader_stage stage
     if (state.second.size() < (first + count))
         state.second.resize(first + count);
 
-    if (descriptors.size() < first + count)
-        descriptors.resize(first + count);
+    if (push_descriptors.size() < first + count)
+        push_descriptors.resize(first + count);
 
     for (uint32_t i = 0; i < count; ++i)
     {
@@ -299,8 +402,8 @@ static void on_bind_descriptor_tables(command_list* cmd_list, shader_stage stage
                 max_descriptor_size = std::max(max_descriptor_size, range.binding + range.count);
         }
 
-        if (descriptors[first + i].size() < max_descriptor_size)
-            descriptors[first + i].resize(max_descriptor_size);
+        if (push_descriptors[first + i].size() < max_descriptor_size)
+            push_descriptors[first + i].resize(max_descriptor_size);
 
         for (uint32_t k = 0; k < param.descriptor_table.count; ++k)
         {
@@ -313,7 +416,7 @@ static void on_bind_descriptor_tables(command_list* cmd_list, shader_stage stage
             descriptor_heap heap = { 0 };
             cmd_list->get_device()->get_descriptor_heap_offset(tables[i], range.binding, 0, &heap, &base_offset);
 
-            descriptor_state.set_all_descriptors(heap, base_offset, range.count, descriptors[first + i], range.binding);
+            descriptor_state.set_all_descriptors(heap, base_offset, range.count, push_descriptors[first + i], range.binding);
         }
     }
 }
@@ -325,23 +428,30 @@ static void on_bind_descriptor_tables_no_track(command_list* cmd_list, shader_st
     if (idx < 0)
         return;
 
-    auto& state = cmd_list->get_private_data<state_tracking>().descriptor_tables[idx];
-    auto& state_stages = cmd_list->get_private_data<state_tracking>().descriptor_tables_stages[idx];
+    auto& state_tracker = cmd_list->get_private_data<state_tracking>();
+    auto& [tables_layout, descriptor_tables] = state_tracker.descriptor_tables[idx];
+    auto& state_stages = state_tracker.descriptor_tables_stages[idx];
+    auto& [push_layout, push_descriptors] = state_tracker.push_descriptors[idx];
+    auto& [const_layout, push_constants] = state_tracker.push_constants[idx];
 
-    if (layout != state.first)
+    if (layout != tables_layout)
     {
-        state.second.clear(); // Layout changed, which resets all descriptor set bindings
+        descriptor_tables.clear(); // Layout changed, which resets all descriptor set bindings
+        push_constants.clear();
+        push_descriptors.clear();
     }
 
-    state.first = layout;
+    tables_layout = layout;
+    push_layout = layout;
+    const_layout = layout;
     state_stages = stages;
 
-    if (state.second.size() < (first + count))
-        state.second.resize(first + count);
+    if (descriptor_tables.size() < (first + count))
+        descriptor_tables.resize(first + count);
 
     for (uint32_t i = 0; i < count; ++i)
     {
-        state.second[i + first] = tables[i];
+        descriptor_tables[i + first] = tables[i];
     }
 }
 
@@ -352,7 +462,7 @@ static void on_push_descriptors(command_list* cmd_list, shader_stage stages, pip
     if (idx < 0)
         return;
 
-    auto& [desc_layout, descriptors] = cmd_list->get_private_data<state_tracking>().descriptors[idx];
+    auto& [desc_layout, descriptors] = cmd_list->get_private_data<state_tracking>().push_descriptors[idx];
 
     desc_layout = layout;
 
@@ -387,6 +497,7 @@ static void on_push_descriptors(command_list* cmd_list, shader_stage stages, pip
             descriptor.view = static_cast<const resource_view*>(update.descriptors)[i];
             break;
         case descriptor_type::constant_buffer:
+        case descriptor_type::shader_storage_buffer:
             descriptor.constant = static_cast<const buffer_range*>(update.descriptors)[i];
         }
     }
@@ -431,6 +542,57 @@ static void on_reshade_present(effect_runtime* runtime)
         on_reset_command_list(runtime->get_command_queue()->get_immediate_command_list());
 }
 
+void state_block::start_resource_barrier_tracking(reshade::api::resource res, reshade::api::resource_usage current_usage)
+{
+    const auto& restrack = resource_barrier_track.find(res.handle);
+
+    if (restrack != resource_barrier_track.end())
+    {
+        restrack->second.ref_count++;
+    }
+    else
+    {
+        resource_barrier_track.emplace(res.handle, barrier_track{ current_usage, 1 });
+    }
+}
+
+reshade::api::resource_usage state_block::stop_resource_barrier_tracking(reshade::api::resource res)
+{
+    const auto& restrack = resource_barrier_track.find(res.handle);
+
+    if (restrack != resource_barrier_track.end())
+    {
+        resource_usage usage = restrack->second.usage;
+
+        restrack->second.ref_count--;
+        if (restrack->second.ref_count <= 0)
+        {
+            resource_barrier_track.erase(res.handle);
+        }
+
+        return usage;
+    }
+
+    return resource_usage::undefined;
+}
+
+static void on_barrier(command_list* cmd_list, uint32_t count, const resource* resources, const resource_usage* old_states, const resource_usage* new_states)
+{
+    auto& barrier_track = cmd_list->get_private_data<state_tracking>().resource_barrier_track;
+    if (barrier_track.size() > 0)
+    {
+        for (uint32_t i = 0; i < count; i++)
+        {
+            const auto& restrack = barrier_track.find(resources[i].handle);
+
+            if (restrack != barrier_track.end())
+            {
+                restrack->second.usage = new_states[i];
+            }
+        }
+    }
+}
+
 void state_tracking::register_events(bool track)
 {
     track_descriptors = track;
@@ -445,12 +607,14 @@ void state_tracking::register_events(bool track)
     reshade::register_event<reshade::addon_event::bind_viewports>(on_bind_viewports);
     reshade::register_event<reshade::addon_event::bind_scissor_rects>(on_bind_scissor_rects);
     reshade::register_event<reshade::addon_event::reshade_present>(on_reshade_present);
+    reshade::register_event<reshade::addon_event::barrier>(on_barrier);
+
+    reshade::register_event<reshade::addon_event::push_descriptors>(on_push_descriptors);
+    reshade::register_event<reshade::addon_event::push_constants>(on_push_constants);
 
     if (track_descriptors)
     {
         reshade::register_event<reshade::addon_event::bind_descriptor_tables>(on_bind_descriptor_tables);
-        reshade::register_event<reshade::addon_event::push_descriptors>(on_push_descriptors);
-        reshade::register_event<reshade::addon_event::push_constants>(on_push_constants);
     }
     else
     {
@@ -472,12 +636,14 @@ void state_tracking::unregister_events()
     reshade::unregister_event<reshade::addon_event::bind_viewports>(on_bind_viewports);
     reshade::unregister_event<reshade::addon_event::bind_scissor_rects>(on_bind_scissor_rects);
     reshade::unregister_event<reshade::addon_event::reshade_present>(on_reshade_present);
+    reshade::unregister_event<reshade::addon_event::barrier>(on_barrier);
+
+    reshade::unregister_event<reshade::addon_event::push_descriptors>(on_push_descriptors);
+    reshade::unregister_event<reshade::addon_event::push_constants>(on_push_constants);
 
     if (track_descriptors)
     {
         reshade::unregister_event<reshade::addon_event::bind_descriptor_tables>(on_bind_descriptor_tables);
-        reshade::unregister_event<reshade::addon_event::push_descriptors>(on_push_descriptors);
-        reshade::unregister_event<reshade::addon_event::push_constants>(on_push_constants);
     }
     else
     {

--- a/src/StateTracking.h
+++ b/src/StateTracking.h
@@ -66,8 +66,8 @@ namespace StateTracking
         constexpr root_entry(const reshade::api::descriptor_table& table) : type(root_entry_type::descriptor_table), buffer_index(-1), descriptor_table(table) {}
 
         root_entry_type type = root_entry_type::undefined;
-        int32_t buffer_index;
-        reshade::api::descriptor_table descriptor_table;
+        int32_t buffer_index = -1;;
+        reshade::api::descriptor_table descriptor_table = {};
     };
 
     struct state_block
@@ -108,7 +108,6 @@ namespace StateTracking
         uint32_t sample_mask = 0xFFFFFFFF;
         uint32_t front_stencil_reference_value = 0;
         uint32_t back_stencil_reference_value = 0;
-        uint32_t srgb_write_enable = 0;
         std::vector<reshade::api::viewport> viewports;
         std::vector<reshade::api::rect> scissor_rects;
 

--- a/src/ToggleGroup.cpp
+++ b/src/ToggleGroup.cpp
@@ -52,6 +52,7 @@ namespace ShaderToggler
         _extractResourceViews = false;
         _matchSwapchainResolution = true;
         _copyTextureBinding = false;
+        _previewClearAlpha = true;
     }
 
 
@@ -229,6 +230,7 @@ namespace ShaderToggler
         iniFile.SetUInt("BindingRenderTargetIndex", _bindingRTIndex, "", sectionRoot);
         iniFile.SetUInt("BindingInvocationLocation", _bindingInvocationLocation, "", sectionRoot);
         iniFile.SetUInt("BindingMatchSwapchainResolutionOnly", _bindingMatchSwapchainResolution, "", sectionRoot);
+        iniFile.SetBool("ClearPreviewAlpha", _previewClearAlpha, "", sectionRoot);
     }
 
 
@@ -472,5 +474,7 @@ namespace ShaderToggler
         {
             _bindingMatchSwapchainResolution = _matchSwapchainResolution; //fallback to effect invocation location when loading old configs
         }
+
+        bool _previewClearAlpha = iniFile.GetBoolOrDefault("ClearPreviewAlpha", sectionRoot, true);
     }
 }

--- a/src/ToggleGroup.h
+++ b/src/ToggleGroup.h
@@ -143,6 +143,8 @@ namespace ShaderToggler
         const std::unordered_map<std::string, std::tuple<uintptr_t, bool>>& GetVarOffsetMapping() const { return _varOffsetMapping; }
         bool SetVarMapping(uintptr_t, std::string&, bool);
         bool RemoveVarMapping(std::string&);
+        bool getClearPreviewAlpha() const { return _previewClearAlpha; }
+        void setClearPreviewAlpha(bool previewClearAlpha) { _previewClearAlpha = previewClearAlpha; }
         void dispatchCBCycle(DescriptorCycle cycle) { _cbCycle = cycle; }
         DescriptorCycle consumeCBCycle() 
         { 
@@ -195,6 +197,7 @@ namespace ShaderToggler
         bool _extractConstants;
         bool _extractResourceViews;
         bool _clearBindings;
+        bool _previewClearAlpha = true;
         bool _hasTechniqueExceptions; // _preferredTechniques are handled as exception to _allowAllTechniques
         uint32_t _matchSwapchainResolution = SWAPCHAIN_MATCH_MODE_RESOLUTION;
         uint32_t _bindingMatchSwapchainResolution = SWAPCHAIN_MATCH_MODE_RESOLUTION;

--- a/src/resource.h
+++ b/src/resource.h
@@ -8,12 +8,14 @@
 #define LICENSE_SIGMATCH                104
 #define LICENSE_REST                    105
 #define LICENSE_IMGUI                   106
+#define SHADER_FULLSCREEN_VS_4_0        107
+#define SHADER_PREVIEW_COPY_PS_4_0      108
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        107
+#define _APS_NEXT_RESOURCE_VALUE        109
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1001
 #define _APS_NEXT_SYMED_VALUE           101

--- a/src/resource.h
+++ b/src/resource.h
@@ -10,12 +10,14 @@
 #define LICENSE_IMGUI                   106
 #define SHADER_FULLSCREEN_VS_4_0        107
 #define SHADER_PREVIEW_COPY_PS_4_0      108
+#define SHADER_FULLSCREEN_VS_3_0        109
+#define SHADER_PREVIEW_COPY_PS_3_0      110
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        109
+#define _APS_NEXT_RESOURCE_VALUE        111
 #define _APS_NEXT_COMMAND_VALUE         40001
 #define _APS_NEXT_CONTROL_VALUE         1001
 #define _APS_NEXT_SYMED_VALUE           101

--- a/src/shader/fullscreen_vs_3_0.hlsl
+++ b/src/shader/fullscreen_vs_3_0.hlsl
@@ -1,0 +1,11 @@
+struct PS_INPUT
+{
+	float4 pos : POSITION;
+	float2 uv : TEXCOORD;
+};
+
+void main(float2 uv : TEXCOORD, out PS_INPUT output)
+{
+	output.uv = uv;
+	output.pos = float4(uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}

--- a/src/shader/fullscreen_vs_4_0.hlsl
+++ b/src/shader/fullscreen_vs_4_0.hlsl
@@ -1,0 +1,6 @@
+void main(uint id : SV_VERTEXID, out float4 pos : SV_POSITION, out float2 uv : TEXCOORD0)
+{
+	uv.x = (id == 1) ? 2.0 : 0.0;
+	uv.y = (id == 2) ? 2.0 : 0.0;
+	pos = float4(uv * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
+}

--- a/src/shader/preview_copy_ps_3_0.hlsl
+++ b/src/shader/preview_copy_ps_3_0.hlsl
@@ -1,0 +1,8 @@
+texture2D t0 : register(t0);
+sampler2D s0 : register(s0);
+
+void main(float4 vpos : VPOS, float2 uv : TEXCOORD, out float4 col : COLOR)
+{
+	col = tex2D(s0, uv);
+	col.a = 1.0; // Clear alpha channel
+}

--- a/src/shader/preview_copy_ps_4_0.hlsl
+++ b/src/shader/preview_copy_ps_4_0.hlsl
@@ -1,0 +1,8 @@
+Texture2D t0 : register(t0);
+SamplerState s0 : register(s0);
+
+void main(float4 vpos : SV_POSITION, float2 uv : TEXCOORD0, out float4 col : SV_TARGET)
+{
+	col = t0.Sample(s0, uv);
+	col.a = 1.0; // Clear alpha channel
+}


### PR DESCRIPTION
Improved DX12 state tracking for next ReShade version and preview alpha clearing:
* Add option to clear alpha channel in the preview of render targets to avoid ImGui blending it completely away. Currently only for dx9-dx11
* Improve state tracking by restoring descriptor heaps in DX12. Requires presumably ReShade 5.9.3+
* Some general refactoring