### PR TITLE
Enabled in screenshot

### DIFF
--- a/src/KeyMonitor.h
+++ b/src/KeyMonitor.h
@@ -81,7 +81,7 @@ namespace ShaderToggler
                         size_t substringLength = strlen(token);
                         uint32_t key = 0;
                         const auto& [ptr, etc] = std::from_chars(token, token + substringLength, key);
-                        key = (key << index);
+                        key = (key << (index * 8));
                         keyCombo |= key;
 
                         index++;

--- a/src/KeyMonitor.h
+++ b/src/KeyMonitor.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <unordered_map>
+#include <charconv>
+#include "KeyData.h"
+#include "reshade_api.hpp"
+
+namespace ShaderToggler
+{
+    enum class KeyState : uint32_t
+    {
+        KEY_STATE_NONE = 0,
+        KET_STATE_PRESSED = 1
+    };
+
+    class __declspec(novtable) KeyMonitor final
+    {
+    public:
+        static const uint32_t KEY_SCREEN_SHOT = 0;
+
+        void SetKeyMonitor(uint32_t id, uint32_t keys)
+        {
+            keyMap[id] = keys;
+            stateMap[id] = KeyState::KEY_STATE_NONE;
+        }
+
+        void PollKeyStates(reshade::api::effect_runtime* runtime)
+        {
+            for (const auto& keys : keyMap)
+            {
+                auto& currentState = stateMap[keys.first];
+
+                if (areKeysPressed(keys.second, runtime))
+                {
+                    currentState = KeyState::KET_STATE_PRESSED;
+                }
+                else
+                {
+                    currentState = KeyState::KEY_STATE_NONE;
+                }
+            }
+        }
+
+        KeyState GetKeyState(uint32_t id)
+        {
+            const auto& state = stateMap.find(id);
+            if (state != stateMap.end())
+            {
+                return state->second;
+            }
+
+            return KeyState::KEY_STATE_NONE;
+        }
+
+        void Init(reshade::api::effect_runtime* runtime)
+        {
+            if (initialized)
+                return;
+
+            static const size_t bufSize = 64;
+            static char buf[bufSize];
+            static size_t readSize = bufSize;
+
+            for (auto& configData : reshadeConfigMapping)
+            {
+                uint32_t keyCombo = 0;
+
+                const auto& [id, data] = configData;
+                const auto& [section, name] = data;
+
+                if (reshade::get_config_value(runtime, section.c_str(), name.c_str(), buf, &readSize))
+                {
+                    const char* delim = ",";
+                    char* next_token = NULL;
+                    char* token = NULL;
+                    uint32_t index = 0;
+
+                    token = strtok_s(buf, delim, &next_token);
+                    while (token != NULL)
+                    {
+                        size_t substringLength = strlen(token);
+                        uint32_t key = 0;
+                        const auto& [ptr, etc] = std::from_chars(token, token + substringLength, key);
+                        key = (key << index);
+                        keyCombo |= key;
+
+                        index++;
+                        token = strtok_s(NULL, delim, &next_token);
+                    }
+
+                    SetKeyMonitor(configData.first, keyCombo);
+                }
+
+                readSize = bufSize;
+            }
+
+            initialized = true;
+        }
+    private:
+        bool initialized = false;
+        std::unordered_map<uint32_t, uint32_t> keyMap;
+        std::unordered_map<uint32_t, KeyState> stateMap;
+
+        const std::unordered_map<uint32_t, std::tuple<std::string, std::string>> reshadeConfigMapping =
+        {
+            { KEY_SCREEN_SHOT, { "INPUT", "KeyScreenshot" } },
+        };
+    };
+}

--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -10,6 +10,28 @@
 
 using effect_queue = std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>;
 
+struct __declspec(novtable) EffectData final {
+    constexpr EffectData() : rendered(false), enabled_in_screenshot(true), timeout(-1) {}
+    constexpr EffectData(reshade::api::effect_technique technique, reshade::api::effect_runtime* runtime)
+    {
+        if (!runtime->get_annotation_bool_from_technique(technique, "enabled_in_screenshot", &enabled_in_screenshot, 1))
+        {
+            enabled_in_screenshot = true;
+        }
+
+        if (!runtime->get_annotation_int_from_technique(technique, "timeout", &timeout, 1))
+        {
+            timeout = -1;
+        }
+
+        rendered = false;
+    }
+
+    bool rendered = false;
+    bool enabled_in_screenshot = true;
+    int32_t timeout = -1;
+};
+
 struct __declspec(novtable) ShaderData final {
     uint32_t activeShaderHash = -1;
     effect_queue bindingsToUpdate;
@@ -88,7 +110,7 @@ struct __declspec(uuid("C63E95B1-4E2F-46D6-A276-E8B4612C069A")) DeviceDataContai
     reshade::api::effect_runtime* current_runtime = nullptr;
     std::atomic_bool rendered_effects = false;
     std::shared_mutex render_mutex;
-    std::unordered_map<std::string, bool> allEnabledTechniques;
+    std::unordered_map<std::string, EffectData> allEnabledTechniques;
     std::shared_mutex binding_mutex;
     std::unordered_map<std::string, TextureBindingData> bindingMap;
     std::unordered_set<std::string> bindingsUpdated;

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -39,11 +39,11 @@ bool RenderingEffectManager::RenderRemainingEffects(effect_runtime* runtime)
     }
 
     RenderingManager::EnumerateTechniques(deviceData.current_runtime, [&deviceData, &commandListData, &cmd_list, &device, &active_rtv, &active_rtv_srgb, &rendered, &res](effect_runtime* runtime, effect_technique technique, string& name) {
-        if (deviceData.allEnabledTechniques.contains(name) && !deviceData.allEnabledTechniques[name])
+        if (deviceData.allEnabledTechniques.contains(name) && !deviceData.allEnabledTechniques[name].rendered)
         {
             runtime->render_technique(technique, cmd_list, active_rtv, active_rtv_srgb);
 
-            deviceData.allEnabledTechniques[name] = true;
+            deviceData.allEnabledTechniques[name].rendered = true;
             rendered = true;
         }
         });
@@ -65,11 +65,12 @@ bool RenderingEffectManager::_RenderEffects(
 
         if (toRenderNames.find(name) != toRenderNames.end())
         {
-            auto tech = techniquesToRender.find(name);
+            const auto& tech = techniquesToRender.find(name);
+            const auto& techState = deviceData.allEnabledTechniques.find(name);
 
-            if (tech != techniquesToRender.end() && !deviceData.allEnabledTechniques.at(name))
+            if (tech != techniquesToRender.end() && !techState->second.rendered)
             {
-                auto& [techName, techData] = *tech;
+                const auto& [techName, techData] = *tech;
                 const auto& [group, _, active_resource] = techData;
 
                 if (active_resource == 0)
@@ -94,7 +95,7 @@ bool RenderingEffectManager::_RenderEffects(
                 resource_desc resDesc = runtime->get_device()->get_resource_desc(active_resource);
                 removalList.push_back(name);
 
-                deviceData.allEnabledTechniques[name] = true;
+                deviceData.allEnabledTechniques[name].rendered = true;
                 rendered = true;
             }
         }

--- a/src/RenderingQueueManager.cpp
+++ b/src/RenderingQueueManager.cpp
@@ -69,14 +69,14 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
 
                 if (group->getAllowAllTechniques())
                 {
-                    for (const auto& [techName, techEnabled] : deviceData.allEnabledTechniques)
+                    for (const auto& [techName, techData] : deviceData.allEnabledTechniques)
                     {
                         if (group->getHasTechniqueExceptions() && group->preferredTechniques().contains(techName))
                         {
                             continue;
                         }
 
-                        if (!techEnabled)
+                        if (!techData.rendered)
                         {
                             if (!sData.techniquesToRender.contains(techName))
                             {
@@ -89,7 +89,8 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
                 else if (group->preferredTechniques().size() > 0) {
                     for (auto& techName : group->preferredTechniques())
                     {
-                        if (deviceData.allEnabledTechniques.contains(techName) && !deviceData.allEnabledTechniques.at(techName))
+                        const auto& techData = deviceData.allEnabledTechniques.find(techName);
+                        if (techData != deviceData.allEnabledTechniques.end() && !techData->second.rendered)
                         {
                             if (!sData.techniquesToRender.contains(techName))
                             {

--- a/src/ShaderToggler.vcxproj
+++ b/src/ShaderToggler.vcxproj
@@ -201,6 +201,7 @@
     <ClInclude Include="crc32_hash.hpp" />
     <ClInclude Include="DescriptorTracking.h" />
     <ClInclude Include="GameHookT.h" />
+    <ClInclude Include="KeyMonitor.h" />
     <ClInclude Include="RenderingBindingManager.h" />
     <ClInclude Include="RenderingEffectManager.h" />
     <ClInclude Include="RenderingPreviewManager.h" />

--- a/src/ShaderToggler.vcxproj.filters
+++ b/src/ShaderToggler.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClInclude Include="RenderingPreviewManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="KeyMonitor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp">


### PR DESCRIPTION
Make REST follow the `enabled_in_screenshot` technique annotation to disable effects while a screenshot is being done. Note it requires to restart the game if the ReShade screenshot hotkey is changed since REST only queries it once on starts. Otherwise I'd have to add some polling and I don't want to.