### PR TITLE
Add option to flip the render target vertically before applying effects

### DIFF
--- a/Shaders/REST_FLIP.fx
+++ b/Shaders/REST_FLIP.fx
@@ -1,0 +1,19 @@
+#include "ReShade.fxh"
+
+void Flip(in float4 pos : SV_Position, in float2 texcoord : Texcoord, out float4 o : SV_Target0)
+{
+    texcoord.y = 1.0 - texcoord.y;
+    float4 color = tex2D(ReShade::BackBuffer, texcoord);
+    
+    o = color.rgb;
+}
+
+technique REST_FLIP
+{
+    pass
+    {
+        VertexShader = PostProcessVS;
+        PixelShader  = Flip; 
+    }
+}
+

--- a/src/AddonUIDisplay.h
+++ b/src/AddonUIDisplay.h
@@ -307,6 +307,7 @@ static void DisplayRenderTargets(AddonImGui::AddonUIData& instance, Rendering::R
     bool retry = group->getRequeueAfterRTMatchingFailure();
     bool tonemap = group->getToneMap();
     bool preserveAlpha = group->getPreserveAlpha();
+    bool flipbuffer = group->getFlipBuffer();
     static const char* swapchainMatchOptions[] = { "RESOLUTION", "ASPECT RATIO", "EXTENDED ASPECT RATIO", "NONE"};
     uint32_t selectedSwapchainMatchMode = group->getMatchSwapchainResolution();
     const char* typesSelectedSwapchainMatchMode = swapchainMatchOptions[selectedSwapchainMatchMode];
@@ -379,6 +380,13 @@ static void DisplayRenderTargets(AddonImGui::AddonUIData& instance, Rendering::R
             ImGui::TableNextRow();
             ImGui::TableNextColumn();
 
+            ImGui::Text("Flip render target");
+            ImGui::TableNextColumn();
+            ImGui::Checkbox("##flipbuffer", &flipbuffer);
+
+            ImGui::TableNextRow();
+            ImGui::TableNextColumn();
+
             ImGui::Text("Preserve target alpha channel");
             ImGui::TableNextColumn();
             ImGui::Checkbox("##preserveAlpha", &preserveAlpha);
@@ -412,6 +420,7 @@ static void DisplayRenderTargets(AddonImGui::AddonUIData& instance, Rendering::R
         group->setInvocationLocation(selectedIndex);
         group->setToneMap(tonemap);
         group->setPreserveAlpha(preserveAlpha);
+        group->setFlipBuffer(flipbuffer);
 
         ImGui::Separator();
 

--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -127,6 +127,7 @@ struct __declspec(novtable) SpecialEffects final
 {
     SpecialEffect tonemap_to_sdr = SpecialEffect{ "REST_TONEMAP_TO_SDR", reshade::api::effect_technique {0} };
     SpecialEffect tonemap_to_hdr = SpecialEffect{ "REST_TONEMAP_TO_HDR", reshade::api::effect_technique {0} };
+    SpecialEffect flip = SpecialEffect{ "REST_FLIP", reshade::api::effect_technique {0} };
 };
 
 struct __declspec(uuid("C63E95B1-4E2F-46D6-A276-E8B4612C069A")) DeviceDataContainer {

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -133,6 +133,11 @@ bool RenderingEffectManager::_RenderEffects(
             continue;
         }
 
+        if (group->getFlipBuffer() && deviceData.specialEffects.flip.technique != 0)
+        {
+            runtime->render_technique(deviceData.specialEffects.flip.technique, cmd_list, view_non_srgb, view_srgb);
+        }
+
         if (group->getToneMap() && deviceData.specialEffects.tonemap_to_sdr.technique != 0)
         {
             runtime->render_technique(deviceData.specialEffects.tonemap_to_sdr.technique, cmd_list, view_non_srgb, view_srgb);
@@ -155,6 +160,11 @@ bool RenderingEffectManager::_RenderEffects(
         if (group->getToneMap() && deviceData.specialEffects.tonemap_to_hdr.technique != 0)
         {
             runtime->render_technique(deviceData.specialEffects.tonemap_to_hdr.technique, cmd_list, view_non_srgb, view_srgb);
+        }
+
+        if (group->getFlipBuffer() && deviceData.specialEffects.flip.technique != 0)
+        {
+            runtime->render_technique(deviceData.specialEffects.flip.technique, cmd_list, view_non_srgb, view_srgb);
         }
 
         if (copyPreserveAlpha)

--- a/src/TechniqueManager.cpp
+++ b/src/TechniqueManager.cpp
@@ -36,6 +36,12 @@ void TechniqueManager::OnReshadeReloadedEffects(reshade::api::effect_runtime* ru
             return;
         }
 
+        if (name == data.specialEffects.flip.name)
+        {
+            data.specialEffects.flip.technique = technique;
+            return;
+        }
+
         const auto& it = data.allTechniques.emplace(name, EffectData{ technique, runtime, enabled });
         data.allSortedTechniques.push_back(make_pair(name, &it.first->second));
     
@@ -54,7 +60,7 @@ bool TechniqueManager::OnReshadeSetTechniqueState(reshade::api::effect_runtime* 
     string techName(charBuffer);
 
     // Prevent REST techniques from being manually enabled
-    if (techName == data.specialEffects.tonemap_to_hdr.name || techName == data.specialEffects.tonemap_to_sdr.name)
+    if (techName == data.specialEffects.tonemap_to_hdr.name || techName == data.specialEffects.tonemap_to_sdr.name || techName == data.specialEffects.flip.name)
     {
         return true;
     }
@@ -112,6 +118,11 @@ bool TechniqueManager::OnReshadeReorderTechniques(reshade::api::effect_runtime* 
         if (name == data.specialEffects.tonemap_to_sdr.name)
         {
             data.specialEffects.tonemap_to_sdr.technique = technique;
+            continue;
+        }
+        if (name == data.specialEffects.flip.name)
+        {
+            data.specialEffects.flip.technique = technique;
             continue;
         }
 

--- a/src/ToggleGroup.cpp
+++ b/src/ToggleGroup.cpp
@@ -235,6 +235,7 @@ namespace ShaderToggler
         iniFile.SetBool("ClearPreviewAlpha", _previewClearAlpha, "", sectionRoot);
         iniFile.SetBool("TonemapHDRtoSDRtoHDR", _tonemapHDRtoSDRtoHDR, "", sectionRoot);
         iniFile.SetBool("PreserveTargetAlphaChannel", _preserveAlpha, "", sectionRoot);
+        iniFile.SetBool("FlipBuffer", _flipBuffer, "", sectionRoot);
     }
 
 
@@ -484,5 +485,7 @@ namespace ShaderToggler
         _tonemapHDRtoSDRtoHDR = iniFile.GetBoolOrDefault("TonemapHDRtoSDRtoHDR", sectionRoot, false);
 
         _preserveAlpha = iniFile.GetBoolOrDefault("PreserveTargetAlphaChannel", sectionRoot, false);
+
+        _flipBuffer = iniFile.GetBoolOrDefault("FlipBuffer", sectionRoot, false);
     }
 }

--- a/src/ToggleGroup.h
+++ b/src/ToggleGroup.h
@@ -150,6 +150,8 @@ namespace ShaderToggler
         void setToneMap(bool tonemap) { _tonemapHDRtoSDRtoHDR = tonemap; }
         bool getPreserveAlpha() const { return _preserveAlpha; }
         void setPreserveAlpha(bool alpha) { _preserveAlpha = alpha; }
+        bool getFlipBuffer() const { return _flipBuffer; }
+        void setFlipBuffer(bool flip) { _flipBuffer = flip; }
         const reshade::api::resource_desc& getTargetBufferDescription() const { return _bufferDesc; }
         void setTargetBufferDescription(const reshade::api::resource_desc& desc) { _bufferDesc = desc; }
         bool getRecreateBuffer() const { return _recreateBuffer; }
@@ -210,6 +212,7 @@ namespace ShaderToggler
         bool _hasTechniqueExceptions; // _preferredTechniques are handled as exception to _allowAllTechniques
         bool _tonemapHDRtoSDRtoHDR = false;
         bool _preserveAlpha = false;
+        bool _flipBuffer = false;
         uint32_t _matchSwapchainResolution = SWAPCHAIN_MATCH_MODE_RESOLUTION;
         uint32_t _bindingMatchSwapchainResolution = SWAPCHAIN_MATCH_MODE_RESOLUTION;
         bool _requeueAfterRTMatchingFailure;


### PR DESCRIPTION
Flips the render target's content vertically before applying effects and again afterwards