### PR TITLE
Remove TTL mechanism. Create views immediately instead of at frame end

### DIFF
--- a/src/RenderingBindingManager.cpp
+++ b/src/RenderingBindingManager.cpp
@@ -208,7 +208,7 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
 
             if (!group->getCopyTextureBinding())
             {
-                GlobalResourceView& view = resourceManager.GetResourceView(active_resource.handle);
+                GlobalResourceView& view = resourceManager.GetResourceView(runtime->get_device(), active_resource.handle);
                 resource_view view_non_srgb = view.srv;
                 resource_view view_srgb = view.rtv_srgb;
 

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -32,7 +32,7 @@ bool RenderingEffectManager::RenderRemainingEffects(effect_runtime* runtime)
 
     resource res = runtime->get_current_back_buffer();
 
-    GlobalResourceView& view = resourceManager.GetResourceView(res.handle);
+    GlobalResourceView& view = resourceManager.GetResourceView(device, res.handle);
     resource_view active_rtv = view.rtv;
     resource_view active_rtv_srgb = view.rtv_srgb;
 
@@ -108,7 +108,7 @@ bool RenderingEffectManager::_RenderEffects(
         resource_view group_view = {};
         resource_desc desc = cmd_list->get_device()->get_resource_desc(active_resource);
         GroupResource& groupResource = group->GetGroupResource(GroupResourceType::RESOURCE_ALPHA);
-        GlobalResourceView& view = resourceManager.GetResourceView(active_resource.handle);
+        GlobalResourceView& view = resourceManager.GetResourceView(runtime->get_device(), active_resource.handle);
         bool copyPreserveAlpha = false;
 
         if (group->getPreserveAlpha())
@@ -281,7 +281,7 @@ void RenderingEffectManager::PreventRuntimeReload(reshade::api::effect_runtime* 
     if (runtimeData.specialEffects[REST_NOOP].technique != 0)
     {
         resource res = runtime->get_current_back_buffer();
-        GlobalResourceView& view = resourceManager.GetResourceView(res.handle);
+        GlobalResourceView& view = resourceManager.GetResourceView(runtime->get_device(), res.handle);
         resource_view active_rtv = view.rtv;
         resource_view active_rtv_srgb = view.rtv_srgb;
 

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -39,13 +39,11 @@ namespace Rendering
         RESOURCE_INVALID = 3,
     };
 
-    constexpr uint32_t GLOBAL_RESOURCE_TTL = 60;
-
     struct __declspec(novtable) GlobalResourceView final
     {
-        constexpr GlobalResourceView() : resource_handle { 0 }, rtv { 0 }, rtv_srgb { 0 }, srv { 0 }, srv_srgb { 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED), ttl(GLOBAL_RESOURCE_TTL) { }
-        constexpr GlobalResourceView(uint64_t handle) : resource_handle{ handle }, rtv{ 0 }, rtv_srgb{ 0 }, srv{ 0 }, srv_srgb{ 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED), ttl(GLOBAL_RESOURCE_TTL) { }
-        constexpr GlobalResourceView(reshade::api::resource_desc desc) : resource_handle { 0 }, rtv { 0 }, rtv_srgb{ 0 }, srv{ 0 }, srv_srgb{ 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED), ttl(GLOBAL_RESOURCE_TTL){ }
+        constexpr GlobalResourceView() : resource_handle { 0 }, rtv { 0 }, rtv_srgb { 0 }, srv { 0 }, srv_srgb { 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED) { }
+        constexpr GlobalResourceView(uint64_t handle) : resource_handle{ handle }, rtv{ 0 }, rtv_srgb{ 0 }, srv{ 0 }, srv_srgb{ 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED) { }
+        constexpr GlobalResourceView(reshade::api::resource_desc desc) : resource_handle { 0 }, rtv { 0 }, rtv_srgb{ 0 }, srv{ 0 }, srv_srgb{ 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED) { }
 
         uint64_t resource_handle;
         reshade::api::resource_view rtv;
@@ -53,7 +51,6 @@ namespace Rendering
         reshade::api::resource_view srv;
         reshade::api::resource_view srv_srgb;
         GlobalResourceState state;
-        uint32_t ttl;
     };
 
     class __declspec(novtable) ResourceManager final
@@ -85,7 +82,7 @@ namespace Rendering
         void OnEffectsReloading(reshade::api::effect_runtime* runtime);
         void OnEffectsReloaded(reshade::api::effect_runtime* runtime);
 
-        GlobalResourceView& GetResourceView(uint64_t handle);
+        GlobalResourceView& GetResourceView(reshade::api::device* device, uint64_t handle);
         void CheckResourceViews(reshade::api::effect_runtime* runtime);
 
         static EmbeddedResourceData GetResourceData(uint16_t id);


### PR DESCRIPTION
Previously unused resource views would be destroyed after 60 frames, but in some games that recreate resources every frame, this might have lead to a memory leak.
Create views immediately instead of deferred now and dispose as soon as they're not used.