### PR TITLE
Separate effect files from technique names

### DIFF
--- a/src/AddonUIData.cpp
+++ b/src/AddonUIData.cpp
@@ -41,10 +41,9 @@ using namespace ShaderToggler;
 using namespace Shim::Constants;
 using namespace std;
 
-AddonUIData::AddonUIData(ShaderManager* pixelShaderManager, ShaderManager* vertexShaderManager, ShaderManager* computeShaderManager, ConstantHandlerBase* cHandler, atomic_uint32_t* activeCollectorFrameCounter,
-    vector<string>* techniques):
+AddonUIData::AddonUIData(ShaderManager* pixelShaderManager, ShaderManager* vertexShaderManager, ShaderManager* computeShaderManager, ConstantHandlerBase* cHandler, atomic_uint32_t* activeCollectorFrameCounter):
     _pixelShaderManager(pixelShaderManager), _vertexShaderManager(vertexShaderManager), _computeShaderManager(computeShaderManager), _activeCollectorFrameCounter(activeCollectorFrameCounter),
-    _allTechniques(techniques), _constantHandler(cHandler)
+    _constantHandler(cHandler)
 {
     _toggleGroupIdShaderEditing = -1;
     _overlayOpacity = 0.2f;
@@ -173,12 +172,6 @@ void AddonUIData::UpdateToggleGroupsForShaderHashes()
         }
     }
 }
-
-const vector<string>* AddonUIData::GetAllTechniques() const
-{
-    return _allTechniques;
-}
-
 
 const atomic_int& AddonUIData::GetToggleGroupIdShaderEditing() const
 {

--- a/src/AddonUIData.cpp
+++ b/src/AddonUIData.cpp
@@ -84,6 +84,14 @@ void AddonUIData::SignalToggleGroupRemoved(reshade::api::effect_runtime* runtime
     }
 }
 
+void AddonUIData::AssignPreferredGroupTechniques(std::unordered_map<std::string, EffectData>& allTechniques)
+{
+    for (auto& it : _toggleGroups)
+    {
+        it.second.AssignPreferredTechniqueData(allTechniques);
+    }
+}
+
 const vector<ToggleGroup*>* AddonUIData::GetToggleGroupsForPixelShaderHash(uint32_t hash)
 {
     const auto& it = _pixelShaderHashToToggleGroups.find(hash);

--- a/src/AddonUIData.h
+++ b/src/AddonUIData.h
@@ -38,6 +38,7 @@
 #include "CDataFile.h"
 #include "ToggleGroup.h"
 #include "ConstantHandlerBase.h"
+#include "EffectData.h"
 
 constexpr auto FRAMECOUNT_COLLECTION_PHASE_DEFAULT = 10;
 constexpr auto HASH_FILE_NAME = "ReshadeEffectShaderToggler.ini";
@@ -168,5 +169,7 @@ namespace AddonImGui
         void SignalToggleGroupRemoved(reshade::api::effect_runtime*, ShaderToggler::ToggleGroup*);
         bool GetPreventRuntimeReload() const { return _preventRuntimeReload; }
         void SetPreventRuntimeReload(bool reload) { _preventRuntimeReload = reload; }
+
+        void AssignPreferredGroupTechniques(std::unordered_map<std::string, EffectData>& allTechniques);
     };
 }

--- a/src/AddonUIData.h
+++ b/src/AddonUIData.h
@@ -96,7 +96,6 @@ namespace AddonImGui
         ShaderToggler::ShaderManager* _computeShaderManager;
         Shim::Constants::ConstantHandlerBase* _constantHandler;
         std::atomic_uint32_t* _activeCollectorFrameCounter;
-        std::vector<std::string>* _allTechniques;
         std::atomic_uint _invocationLocation = 0;
         std::atomic_uint _descriptorIndex = 0;
         std::atomic_int _toggleGroupIdShaderEditing = -1;
@@ -119,8 +118,7 @@ namespace AddonImGui
 
         std::vector<std::function<void(reshade::api::effect_runtime*, ShaderToggler::ToggleGroup*)>> _removalCallbacks;
     public:
-        AddonUIData(ShaderToggler::ShaderManager* pixelShaderManager, ShaderToggler::ShaderManager* vertexShaderManager, ShaderToggler::ShaderManager* computeShaderManager, Shim::Constants::ConstantHandlerBase* constants, std::atomic_uint32_t* activeCollectorFrameCounter,
-            std::vector<std::string>* techniques);
+        AddonUIData(ShaderToggler::ShaderManager* pixelShaderManager, ShaderToggler::ShaderManager* vertexShaderManager, ShaderToggler::ShaderManager* computeShaderManager, Shim::Constants::ConstantHandlerBase* constants, std::atomic_uint32_t* activeCollectorFrameCounter);
         std::unordered_map<int, ShaderToggler::ToggleGroup>& GetToggleGroups();
         const std::vector<ShaderToggler::ToggleGroup*>* GetToggleGroupsForPixelShaderHash(uint32_t hash);
         const std::vector<ShaderToggler::ToggleGroup*>* GetToggleGroupsForVertexShaderHash(uint32_t hash);
@@ -146,7 +144,6 @@ namespace AddonImGui
         std::atomic_uint& GetDescriptorIndex() { return _descriptorIndex; }
         void SetCurrentTabType(TabType type) { _currentTab = type; }
         TabType GetCurrentTabType() const { return _currentTab; }
-        const std::vector<std::string>* GetAllTechniques() const;
         int* StartValueFramecountCollectionPhase() { return &_startValueFramecountCollectionPhase; }
         float* OverlayOpacity() { return &_overlayOpacity; }
         std::atomic_uint32_t* ActiveCollectorFrameCounter() { return _activeCollectorFrameCounter; }

--- a/src/EffectData.h
+++ b/src/EffectData.h
@@ -4,6 +4,7 @@
 
 struct __declspec(novtable) EffectData final {
     constexpr EffectData() : rendered(false), enabled_in_screenshot(true), technique({}), timeout(-1) {}
+    constexpr EffectData(reshade::api::effect_technique tech) : rendered(false), enabled_in_screenshot(true), technique(tech), timeout(-1) {}
     constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime) : EffectData(tech, runtime, false) {}
     constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime, bool active)
     {
@@ -25,18 +26,11 @@ struct __declspec(novtable) EffectData final {
         technique = tech;
         enabled = active;
     }
-    constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime, bool active, std::string& tech_name, std::string& eff_name) : EffectData(tech, runtime, active)
-    {
-        technique_name = tech_name;
-        effect_name = eff_name;
-    }
 
-    bool rendered = false;
+    mutable bool rendered = false;
     bool enabled_in_screenshot = true;
     bool enabled = false;
     reshade::api::effect_technique technique = {};
-    std::string technique_name;
-    std::string effect_name;
     int32_t timeout = -1;
     std::chrono::steady_clock::time_point timeout_start;
 };

--- a/src/EffectData.h
+++ b/src/EffectData.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <chrono>
+#include "reshade.hpp"
+
+struct __declspec(novtable) EffectData final {
+    constexpr EffectData() : rendered(false), enabled_in_screenshot(true), technique({}), timeout(-1) {}
+    constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime) : EffectData(tech, runtime, false) {}
+    constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime, bool active)
+    {
+        if (!runtime->get_annotation_bool_from_technique(tech, "enabled_in_screenshot", &enabled_in_screenshot, 1))
+        {
+            enabled_in_screenshot = true;
+        }
+
+        if (!runtime->get_annotation_int_from_technique(tech, "timeout", &timeout, 1))
+        {
+            timeout = -1;
+        }
+        else
+        {
+            timeout_start = std::chrono::steady_clock::now();
+        }
+
+        rendered = false;
+        technique = tech;
+        enabled = active;
+    }
+    constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime, bool active, std::string& tech_name, std::string& eff_name) : EffectData(tech, runtime, active)
+    {
+        technique_name = tech_name;
+        effect_name = eff_name;
+    }
+
+    bool rendered = false;
+    bool enabled_in_screenshot = true;
+    bool enabled = false;
+    reshade::api::effect_technique technique = {};
+    std::string technique_name;
+    std::string effect_name;
+    int32_t timeout = -1;
+    std::chrono::steady_clock::time_point timeout_start;
+};

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -84,8 +84,7 @@ static ConstantCopyBase* constantCopy = nullptr;
 static bool constantHandlerHooked = false;
 
 static atomic_uint32_t g_activeCollectorFrameCounter = 0;
-static vector<string> allTechniques;
-static AddonUIData g_addonUIData(&g_pixelShaderManager, &g_vertexShaderManager, &g_computeShaderManager, constantHandler, &g_activeCollectorFrameCounter, &allTechniques);
+static AddonUIData g_addonUIData(&g_pixelShaderManager, &g_vertexShaderManager, &g_computeShaderManager, constantHandler, &g_activeCollectorFrameCounter);
 
 static KeyMonitor keyMonitor;
 static Rendering::ResourceManager resourceManager;
@@ -95,7 +94,7 @@ static Rendering::RenderingEffectManager renderingEffectManager(g_addonUIData, r
 static Rendering::RenderingBindingManager renderingBindingManager(g_addonUIData, resourceManager, groupResourceManager);
 static Rendering::RenderingPreviewManager renderingPreviewManager(g_addonUIData, resourceManager, renderingShaderManager);
 static Rendering::RenderingQueueManager renderingQueueManager(g_addonUIData, resourceManager);
-static ShaderToggler::TechniqueManager techniqueManager(keyMonitor, allTechniques);
+static ShaderToggler::TechniqueManager techniqueManager(keyMonitor);
 
 // TODO: actually implement ability to turn off srgb-view generation
 static vector<effect_runtime*> runtimes;

--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -117,7 +117,7 @@ struct __declspec(uuid("C63E95B1-4E2F-46D6-A276-E8B4612C069A")) DeviceDataContai
 struct __declspec(uuid("838BAF1D-95C0-4A7E-A517-052642879986")) RuntimeDataContainer {
     std::shared_mutex technique_mutex;
     std::unordered_map<std::string, EffectData> allTechniques;
-    std::unordered_map<std::string, EffectData*> allEnabledTechniques;
+    std::unordered_set<EffectData*> allEnabledTechniques;
 
     SpecialEffect specialEffects[4] = {
         SpecialEffect{ "REST_TONEMAP_TO_SDR", reshade::api::effect_technique {0} },

--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -8,41 +8,10 @@
 #include "reshade.hpp"
 #include "CDataFile.h"
 #include "ToggleGroup.h"
+#include "EffectData.h"
 
-using effect_queue = std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>;
+using effect_queue = std::unordered_map<EffectData*, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>;
 using binding_queue = std::unordered_map<ShaderToggler::ToggleGroup*, std::tuple<uint64_t, reshade::api::resource>>;
-
-struct __declspec(novtable) EffectData final {
-    constexpr EffectData() : rendered(false), enabled_in_screenshot(true), technique({}), timeout(-1) {}
-    constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime) : EffectData(tech, runtime, false) {}
-    constexpr EffectData(reshade::api::effect_technique tech, reshade::api::effect_runtime* runtime, bool active)
-    {
-        if (!runtime->get_annotation_bool_from_technique(tech, "enabled_in_screenshot", &enabled_in_screenshot, 1))
-        {
-            enabled_in_screenshot = true;
-        }
-
-        if (!runtime->get_annotation_int_from_technique(tech, "timeout", &timeout, 1))
-        {
-            timeout = -1;
-        }
-        else
-        {
-            timeout_start = std::chrono::steady_clock::now();
-        }
-
-        rendered = false;
-        technique = tech;
-        enabled = active;
-    }
-
-    bool rendered = false;
-    bool enabled_in_screenshot = true;
-    bool enabled = false;
-    reshade::api::effect_technique technique = {};
-    int32_t timeout = -1;
-    std::chrono::steady_clock::time_point timeout_start;
-};
 
 struct __declspec(novtable) ShaderData final {
     uint32_t activeShaderHash = -1;
@@ -138,6 +107,7 @@ struct __declspec(uuid("C63E95B1-4E2F-46D6-A276-E8B4612C069A")) DeviceDataContai
     reshade::api::effect_runtime* current_runtime = nullptr;
     std::atomic_bool rendered_effects = false;
     std::shared_mutex binding_mutex;
+    std::shared_mutex render_mutex;
     std::unordered_set<const ShaderToggler::ToggleGroup*> bindingsUpdated;
     std::unordered_set<const ShaderToggler::ToggleGroup*> constantsUpdated;
     std::unordered_set<const ShaderToggler::ToggleGroup*> srvUpdated;
@@ -145,10 +115,10 @@ struct __declspec(uuid("C63E95B1-4E2F-46D6-A276-E8B4612C069A")) DeviceDataContai
 };
 
 struct __declspec(uuid("838BAF1D-95C0-4A7E-A517-052642879986")) RuntimeDataContainer {
-    std::shared_mutex render_mutex;
+    std::shared_mutex technique_mutex;
     std::unordered_map<std::string, EffectData> allTechniques;
-    std::vector<std::pair<std::string, EffectData*>> allSortedTechniques;
     std::unordered_map<std::string, EffectData*> allEnabledTechniques;
+
     SpecialEffect specialEffects[4] = {
         SpecialEffect{ "REST_TONEMAP_TO_SDR", reshade::api::effect_technique {0} },
         SpecialEffect{ "REST_TONEMAP_TO_HDR", reshade::api::effect_technique {0} },

--- a/src/RenderingBindingManager.cpp
+++ b/src/RenderingBindingManager.cpp
@@ -271,6 +271,8 @@ void RenderingBindingManager::UpdateTextureBindings(command_list* cmd_list, uint
     // Remove call location from queue
     commandListData.commandQueue &= ~(invocation << (callLocation * MATCH_DELIMITER));
 
+    unique_lock<shared_mutex> mtx(deviceData.binding_mutex);
+
     if (deviceData.current_runtime == nullptr || (commandListData.ps.bindingsToUpdate.size() == 0 && commandListData.vs.bindingsToUpdate.size() == 0 && commandListData.cs.bindingsToUpdate.size() == 0)) {
         return;
     }
@@ -303,7 +305,6 @@ void RenderingBindingManager::UpdateTextureBindings(command_list* cmd_list, uint
     vector<ToggleGroup*> vsRemovalList;
     vector<ToggleGroup*> csRemovalList;
 
-    unique_lock<shared_mutex> mtx(deviceData.binding_mutex);
     if (psToUpdateBindings.size() > 0)
     {
         _UpdateTextureBindings(cmd_list, deviceData, commandListData.ps.bindingsToUpdate, psRemovalList, psToUpdateBindings);

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -41,11 +41,11 @@ bool RenderingEffectManager::RenderRemainingEffects(effect_runtime* runtime)
 
     for (auto& eff : runtimeData.allEnabledTechniques)
     {
-        if (!eff.second->rendered)
+        if (!eff->rendered)
         {
-            runtime->render_technique(eff.second->technique, cmd_list, active_rtv, active_rtv_srgb);
+            runtime->render_technique(eff->technique, cmd_list, active_rtv, active_rtv_srgb);
 
-            eff.second->rendered = true;
+            eff->rendered = true;
             rendered = true;
         }
     }

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -67,29 +67,17 @@ bool RenderingEffectManager::_RenderEffects(
 
     unordered_map<ToggleGroup*, pair<vector<EffectData*>, resource>> groupTechMap;
 
-    for (const auto& sTech : runtimeData.allEnabledTechniques)
+    for (const auto& sTech : techniquesToRender)
     {
-        if (sTech.second->enabled && !sTech.second->rendered && toRenderNames.contains(sTech.second))
+        if (sTech.first->enabled && !sTech.first->rendered && toRenderNames.contains(sTech.first))
         {
-            const auto& tech = techniquesToRender.find(sTech.second);
+            const auto& [techName, techData] = sTech;
+            const auto& [group, _, active_resource] = techData;
 
-            if (tech != techniquesToRender.end())
-            {
-                const auto& [techName, techData] = *tech;
-                const auto& [group, _, active_resource] = techData;
+            auto& [gEffects, gResource] = groupTechMap[group];
 
-                const auto& curTechEntry = groupTechMap.find(group);
-
-                if (curTechEntry == groupTechMap.end())
-                {
-                    const auto& nEntry = groupTechMap.emplace(group, make_pair(vector<EffectData*>(), active_resource));
-                    nEntry.first->second.first.push_back(sTech.second);
-                }
-                else
-                {
-                    curTechEntry->second.first.push_back(sTech.second);
-                }
-            }
+            gEffects.push_back(sTech.first);
+            gResource = active_resource;
         }
     }
 

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -26,7 +26,6 @@ bool RenderingEffectManager::RenderRemainingEffects(effect_runtime* runtime)
     command_list* cmd_list = runtime->get_command_queue()->get_immediate_command_list();
     device* device = runtime->get_device();
     RuntimeDataContainer& runtimeData = runtime->get_private_data<RuntimeDataContainer>();
-    CommandListDataContainer& commandListData = cmd_list->get_private_data<CommandListDataContainer>();
     DeviceDataContainer& deviceData = device->get_private_data<DeviceDataContainer>();
     bool rendered = false;
 
@@ -40,15 +39,16 @@ bool RenderingEffectManager::RenderRemainingEffects(effect_runtime* runtime)
         return false;
     }
 
-    RenderingManager::EnumerateTechniques(runtime, [&runtimeData, &cmd_list, &active_rtv, &active_rtv_srgb, &rendered](effect_runtime* runtime, effect_technique technique, string& name) {
-        if (runtimeData.allEnabledTechniques.contains(name) && !runtimeData.allEnabledTechniques[name]->rendered)
+    for (auto& eff : runtimeData.allEnabledTechniques)
+    {
+        if (!eff.second->rendered)
         {
-            runtime->render_technique(technique, cmd_list, active_rtv, active_rtv_srgb);
+            runtime->render_technique(eff.second->technique, cmd_list, active_rtv, active_rtv_srgb);
 
-            runtimeData.allEnabledTechniques[name]->rendered = true;
+            eff.second->rendered = true;
             rendered = true;
         }
-        });
+    }
 
     return rendered;
 }
@@ -57,21 +57,21 @@ bool RenderingEffectManager::_RenderEffects(
     command_list* cmd_list,
     DeviceDataContainer& deviceData,
     RuntimeDataContainer& runtimeData,
-    const unordered_map<string, tuple<ToggleGroup*, uint64_t, resource>>& techniquesToRender,
-    vector<string>& removalList,
-    const unordered_set<string>& toRenderNames)
+    const unordered_map<EffectData*, tuple<ToggleGroup*, uint64_t, resource>>& techniquesToRender,
+    vector<EffectData*>& removalList,
+    const unordered_set<EffectData*>& toRenderNames)
 {
     bool rendered = false;
     CommandListDataContainer& cmdData = cmd_list->get_private_data<CommandListDataContainer>();
     effect_runtime* runtime = deviceData.current_runtime;
 
-    unordered_map<ToggleGroup*, pair<vector<pair<string, EffectData*>>, resource>> groupTechMap;
+    unordered_map<ToggleGroup*, pair<vector<EffectData*>, resource>> groupTechMap;
 
-    for (const auto& sTech : runtimeData.allSortedTechniques)
+    for (const auto& sTech : runtimeData.allEnabledTechniques)
     {
-        if (sTech.second->enabled && !sTech.second->rendered && toRenderNames.contains(sTech.first))
+        if (sTech.second->enabled && !sTech.second->rendered && toRenderNames.contains(sTech.second))
         {
-            const auto& tech = techniquesToRender.find(sTech.first);
+            const auto& tech = techniquesToRender.find(sTech.second);
 
             if (tech != techniquesToRender.end())
             {
@@ -82,12 +82,12 @@ bool RenderingEffectManager::_RenderEffects(
 
                 if (curTechEntry == groupTechMap.end())
                 {
-                    const auto& nEntry = groupTechMap.emplace(group, make_pair(vector<pair<string, EffectData*>>(), active_resource));
-                    nEntry.first->second.first.push_back(make_pair(techName, sTech.second));
+                    const auto& nEntry = groupTechMap.emplace(group, make_pair(vector<EffectData*>(), active_resource));
+                    nEntry.first->second.first.push_back(sTech.second);
                 }
                 else
                 {
-                    curTechEntry->second.first.push_back(make_pair(techName, sTech.second));
+                    curTechEntry->second.first.push_back(sTech.second);
                 }
             }
         }
@@ -152,14 +152,12 @@ bool RenderingEffectManager::_RenderEffects(
 
         for (const auto& effectTech : effectList)
         {
-            const auto& [name, effectData] = effectTech;
-
             deviceData.rendered_effects = true;
 
-            runtime->render_technique(effectData->technique, cmd_list, view_non_srgb, view_srgb);
-            effectData->rendered = true;
+            runtime->render_technique(effectTech->technique, cmd_list, view_non_srgb, view_srgb);
+            effectTech->rendered = true;
 
-            removalList.push_back(name);
+            removalList.push_back(effectTech);
 
             rendered = true;
         }
@@ -201,15 +199,17 @@ void RenderingEffectManager::RenderEffects(command_list* cmd_list, uint64_t call
     // Remove call location from queue
     commandListData.commandQueue &= ~(invocation << (callLocation * MATCH_DELIMITER));
 
+    unique_lock<shared_mutex> renderLock(deviceData.render_mutex);
+
     if (deviceData.current_runtime == nullptr || (commandListData.ps.techniquesToRender.size() == 0 && commandListData.vs.techniquesToRender.size() == 0 && commandListData.cs.techniquesToRender.size() == 0)) {
         return;
     }
 
     RuntimeDataContainer& runtimeData = deviceData.current_runtime->get_private_data<RuntimeDataContainer>();
     bool toRender = false;
-    unordered_set<string> psToRenderNames;
-    unordered_set<string> vsToRenderNames;
-    unordered_set<string> csToRenderNames;
+    unordered_set<EffectData*> psToRenderNames;
+    unordered_set<EffectData*> vsToRenderNames;
+    unordered_set<EffectData*> csToRenderNames;
 
     if (invocation & MATCH_EFFECT_PS)
     {
@@ -227,9 +227,9 @@ void RenderingEffectManager::RenderEffects(command_list* cmd_list, uint64_t call
     }
 
     bool rendered = false;
-    vector<string> psRemovalList;
-    vector<string> vsRemovalList;
-    vector<string> csRemovalList;
+    vector<EffectData*> psRemovalList;
+    vector<EffectData*> vsRemovalList;
+    vector<EffectData*> csRemovalList;
 
     if (psToRenderNames.size() == 0 && vsToRenderNames.size() == 0)
     {
@@ -241,12 +241,12 @@ void RenderingEffectManager::RenderEffects(command_list* cmd_list, uint64_t call
         deviceData.current_runtime->render_effects(cmd_list, resource_view{ 0 }, resource_view{ 0 });
     }
 
-    unique_lock<shared_mutex> dev_mutex(runtimeData.render_mutex);
+    shared_lock<shared_mutex> techLock(runtimeData.technique_mutex);
     rendered =
         (psToRenderNames.size() > 0) && _RenderEffects(cmd_list, deviceData, runtimeData, commandListData.ps.techniquesToRender, psRemovalList, psToRenderNames) ||
         (vsToRenderNames.size() > 0) && _RenderEffects(cmd_list, deviceData, runtimeData, commandListData.vs.techniquesToRender, vsRemovalList, vsToRenderNames) ||
         (csToRenderNames.size() > 0) && _RenderEffects(cmd_list, deviceData, runtimeData, commandListData.cs.techniquesToRender, csRemovalList, csToRenderNames);
-    dev_mutex.unlock();
+    techLock.unlock();
 
     for (auto& g : psRemovalList)
     {

--- a/src/RenderingEffectManager.h
+++ b/src/RenderingEffectManager.h
@@ -25,8 +25,8 @@ namespace Rendering
             reshade::api::command_list* cmd_list,
             DeviceDataContainer& deviceData,
             RuntimeDataContainer& runtimeData,
-            const std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& techniquesToRender,
-            std::vector<std::string>& removalList,
-            const std::unordered_set<std::string>& toRenderNames);
+            const std::unordered_map<EffectData*, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& techniquesToRender,
+            std::vector<EffectData*>& removalList,
+            const std::unordered_set<EffectData*>& toRenderNames);
     };
 }

--- a/src/RenderingManager.cpp
+++ b/src/RenderingManager.cpp
@@ -10,13 +10,18 @@ using namespace std;
 size_t RenderingManager::g_charBufferSize = CHAR_BUFFER_SIZE;
 char RenderingManager::g_charBuffer[CHAR_BUFFER_SIZE];
 
-void RenderingManager::EnumerateTechniques(effect_runtime* runtime, function<void(effect_runtime*, effect_technique, string&)> func)
+void RenderingManager::EnumerateTechniques(effect_runtime* runtime, function<void(effect_runtime*, effect_technique, string&, string&)> func)
 {
     runtime->enumerate_techniques(nullptr, [func](effect_runtime* rt, effect_technique technique) {
         g_charBufferSize = CHAR_BUFFER_SIZE;
         rt->get_technique_name(technique, g_charBuffer, &g_charBufferSize);
         string name(g_charBuffer);
-        func(rt, technique, name);
+
+        g_charBufferSize = CHAR_BUFFER_SIZE;
+        rt->get_technique_effect_name(technique, g_charBuffer, &g_charBufferSize);
+        string eff_name(g_charBuffer);
+
+        func(rt, technique, name, eff_name);
         });
 }
 
@@ -215,8 +220,8 @@ void RenderingManager::QueueOrDequeue(
     command_list* cmd_list,
     DeviceDataContainer& deviceData,
     CommandListDataContainer& commandListData,
-    unordered_map<string, tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& queue,
-    unordered_set<string>& immediateQueue,
+    unordered_map<EffectData*, tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& queue,
+    unordered_set<EffectData*>& immediateQueue,
     uint64_t callLocation,
     uint32_t layoutIndex,
     uint64_t action)

--- a/src/RenderingManager.h
+++ b/src/RenderingManager.h
@@ -61,13 +61,13 @@ namespace Rendering
         static const reshade::api::resource GetCurrentResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
         static bool check_aspect_ratio(float width_to_check, float height_to_check, uint32_t width, uint32_t height, uint32_t matchingMode);
         
-        static void EnumerateTechniques(reshade::api::effect_runtime* runtime, std::function<void(reshade::api::effect_runtime*, reshade::api::effect_technique, std::string&)> func);
+        static void EnumerateTechniques(reshade::api::effect_runtime* runtime, std::function<void(reshade::api::effect_runtime*, reshade::api::effect_technique, std::string&, std::string&)> func);
         static void QueueOrDequeue(
             reshade::api::command_list* cmd_list,
             DeviceDataContainer& deviceData,
             CommandListDataContainer& commandListData,
-            std::unordered_map<std::string, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& queue,
-            std::unordered_set<std::string>& immediateQueue,
+            std::unordered_map<EffectData*, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& queue,
+            std::unordered_set<EffectData*>& immediateQueue,
             uint64_t callLocation,
             uint32_t layoutIndex,
             uint64_t action);

--- a/src/RenderingQueueManager.cpp
+++ b/src/RenderingQueueManager.cpp
@@ -78,25 +78,23 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
 
                         if (!techData->rendered)
                         {
-                            if (!sData.techniquesToRender.contains(techName))
+                            if (!sData.techniquesToRender.contains(techData))
                             {
-                                sData.techniquesToRender.emplace(techName, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
+                                sData.techniquesToRender.emplace(techData, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
                                 queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
                             }
                         }
                     }
                 }
                 else if (group->preferredTechniques().size() > 0) {
-                    for (auto& techName : group->preferredTechniques())
+                    auto& preferred = group->GetPreferredTechniqueData();
+
+                    for (auto& eff : preferred)
                     {
-                        const auto& techData = runtimeData.allEnabledTechniques.find(techName);
-                        if (techData != runtimeData.allEnabledTechniques.end() && !techData->second->rendered)
+                        if (!eff->rendered && !sData.techniquesToRender.contains(eff))
                         {
-                            if (!sData.techniquesToRender.contains(techName))
-                            {
-                                sData.techniquesToRender.emplace(techName, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
-                                queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
-                            }
+                            sData.techniquesToRender.emplace(eff, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
+                            queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
                         }
                     }
                 }
@@ -118,8 +116,9 @@ void RenderingQueueManager::CheckCallForCommandList(reshade::api::command_list* 
     DeviceDataContainer& deviceData = commandList->get_device()->get_private_data<DeviceDataContainer>();
     RuntimeDataContainer& runtimeData = deviceData.current_runtime->get_private_data<RuntimeDataContainer>();
 
-    shared_lock<shared_mutex> r_mutex(runtimeData.render_mutex);
-    shared_lock<shared_mutex> b_mutex(deviceData.binding_mutex);
+    shared_lock<shared_mutex> t_mutex(runtimeData.technique_mutex);
+    unique_lock<shared_mutex> b_mutex(deviceData.binding_mutex);
+    unique_lock<shared_mutex> r_mutex(deviceData.render_mutex);
 
     _CheckCallForCommandList(commandListData.ps, commandListData, deviceData, runtimeData);
     _CheckCallForCommandList(commandListData.vs, commandListData, deviceData, runtimeData);

--- a/src/RenderingQueueManager.cpp
+++ b/src/RenderingQueueManager.cpp
@@ -69,9 +69,11 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
 
                 if (group->getAllowAllTechniques())
                 {
-                    for (const auto& [techName, techData] : runtimeData.allEnabledTechniques)
+                    auto& preferred = group->GetPreferredTechniqueData();
+
+                    for (const auto& techData : runtimeData.allEnabledTechniques)
                     {
-                        if (group->getHasTechniqueExceptions() && group->preferredTechniques().contains(techName))
+                        if (group->getHasTechniqueExceptions() && preferred.contains(techData))
                         {
                             continue;
                         }

--- a/src/ShaderToggler.vcxproj
+++ b/src/ShaderToggler.vcxproj
@@ -200,6 +200,7 @@
     <ClInclude Include="ConstantManager.h" />
     <ClInclude Include="crc32_hash.hpp" />
     <ClInclude Include="DescriptorTracking.h" />
+    <ClInclude Include="EffectData.h" />
     <ClInclude Include="GameHookT.h" />
     <ClInclude Include="KeyMonitor.h" />
     <ClInclude Include="RenderingBindingManager.h" />

--- a/src/ShaderToggler.vcxproj.filters
+++ b/src/ShaderToggler.vcxproj.filters
@@ -132,6 +132,9 @@
     <ClInclude Include="ToggleGroupResourceManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="EffectData.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Main.cpp">

--- a/src/TechniqueManager.cpp
+++ b/src/TechniqueManager.cpp
@@ -7,7 +7,7 @@ using namespace std;
 size_t TechniqueManager::charBufferSize = CHAR_BUFFER_SIZE;
 char TechniqueManager::charBuffer[CHAR_BUFFER_SIZE];
 
-TechniqueManager::TechniqueManager(KeyMonitor& kMonitor, vector<string>& techniqueCollection) : keyMonitor(kMonitor), allTechniques(techniqueCollection)
+TechniqueManager::TechniqueManager(KeyMonitor& kMonitor) : keyMonitor(kMonitor)
 {
 
 }
@@ -45,10 +45,8 @@ void TechniqueManager::OnReshadeReloadedEffects(reshade::api::effect_runtime* ru
 
     data.allEnabledTechniques.clear();
     data.allTechniques.clear();
-    allTechniques.clear();
 
     Rendering::RenderingManager::EnumerateTechniques(runtime, [&data, this](effect_runtime* runtime, effect_technique technique, string& name, string& eff_name) {
-        allTechniques.push_back(name);
         bool enabled = runtime->get_technique_state(technique);
 
         // Assign technique handles to REST effects
@@ -68,11 +66,11 @@ void TechniqueManager::OnReshadeReloadedEffects(reshade::api::effect_runtime* ru
             return;
         }
 
-        const auto& it = data.allTechniques.emplace(name, EffectData{ technique, runtime, enabled, name, eff_name });
-    
+        const auto& it = data.allTechniques.emplace(name + " [" + eff_name + "]", EffectData{technique, runtime, enabled});
+
         if (enabled)
         {
-            data.allEnabledTechniques.emplace(name, &it.first->second);
+            data.allEnabledTechniques.emplace(&it.first->second);
         }
         });
 
@@ -99,6 +97,12 @@ bool TechniqueManager::OnReshadeSetTechniqueState(reshade::api::effect_runtime* 
     runtime->get_technique_name(technique, charBuffer, &charBufferSize);
     string techName(charBuffer);
 
+    charBufferSize = CHAR_BUFFER_SIZE;
+    runtime->get_technique_effect_name(technique, charBuffer, &charBufferSize);
+    string effName(charBuffer);
+
+    std::string effKey = techName + " [" + effName + "]";
+
     // Prevent REST techniques from being manually enabled
     for (uint32_t j = 0; j < REST_EFFECTS_COUNT; j++)
     {
@@ -108,7 +112,7 @@ bool TechniqueManager::OnReshadeSetTechniqueState(reshade::api::effect_runtime* 
         }
     }
 
-    const auto& it = data.allTechniques.find(techName);
+    const auto& it = data.allTechniques.find(effKey);
 
     if (it == data.allTechniques.end())
     {
@@ -119,16 +123,16 @@ bool TechniqueManager::OnReshadeSetTechniqueState(reshade::api::effect_runtime* 
 
     if (!enabled)
     {
-        if (data.allEnabledTechniques.contains(techName))
+        if (data.allEnabledTechniques.contains(&it->second))
         {
-            data.allEnabledTechniques.erase(techName);
+            data.allEnabledTechniques.erase(&it->second);
         }
     }
     else
     {
-        if (data.allEnabledTechniques.find(techName) == data.allEnabledTechniques.end())
+        if (data.allEnabledTechniques.find(&it->second) == data.allEnabledTechniques.end())
         {
-            data.allEnabledTechniques.emplace(techName, &it->second);
+            data.allEnabledTechniques.emplace(&it->second);
         }
     }
 
@@ -155,6 +159,8 @@ bool TechniqueManager::OnReshadeReorderTechniques(reshade::api::effect_runtime* 
         runtime->get_technique_effect_name(technique, charBuffer, &charBufferSize);
         string eff_name(charBuffer);
 
+        std::string effKey = name + " [" + eff_name + "]";
+
         bool enabled = runtime->get_technique_state(technique);
 
         // Assign technique handles to REST effects
@@ -174,11 +180,11 @@ bool TechniqueManager::OnReshadeReorderTechniques(reshade::api::effect_runtime* 
             continue;
         }
 
-        const auto& it = data.allTechniques.emplace(name, EffectData{ technique, runtime, enabled, name, eff_name });
+        const auto& it = data.allTechniques.emplace(effKey, EffectData{ technique, runtime, enabled });
 
         if (enabled)
         {
-            data.allEnabledTechniques.emplace(name, &it.first->second);
+            data.allEnabledTechniques.emplace(&it.first->second);
         }
     }
 
@@ -192,24 +198,26 @@ void TechniqueManager::OnReshadePresent(reshade::api::effect_runtime* runtime)
 
     for (auto el = deviceData.allEnabledTechniques.begin(); el != deviceData.allEnabledTechniques.end();)
     {
+        EffectData const* eff = *el;
+
         // Get rid of techniques with a timeout. We don't actually have a timer, so just get rid of them after they were rendered at least once
-        if (el->second->timeout >= 0 &&
-            el->second->technique != 0 &&
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - el->second->timeout_start).count() >= el->second->timeout)
+        if (eff->timeout >= 0 &&
+            eff->technique != 0 &&
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - eff->timeout_start).count() >= eff->timeout)
         {
-            runtime->set_technique_state(el->second->technique, false);
+            runtime->set_technique_state(eff->technique, false);
             el = deviceData.allEnabledTechniques.erase(el);
             continue;
         }
 
         // Prevent effects that are not supposed to be in screenshots from being rendered when ReShade is taking a screenshot
-        if (!el->second->enabled_in_screenshot && keyMonitor.GetKeyState(KeyMonitor::KEY_SCREEN_SHOT) == KeyState::KET_STATE_PRESSED)
+        if (!eff->enabled_in_screenshot && keyMonitor.GetKeyState(KeyMonitor::KEY_SCREEN_SHOT) == KeyState::KET_STATE_PRESSED)
         {
-            el->second->rendered = true;
+            eff->rendered = true;
         }
         else
         {
-            el->second->rendered = false;
+            eff->rendered = false;
         }
 
         el++;

--- a/src/TechniqueManager.h
+++ b/src/TechniqueManager.h
@@ -12,7 +12,7 @@ namespace ShaderToggler
     class __declspec(novtable) TechniqueManager final
     {
     public:
-        TechniqueManager(ShaderToggler::KeyMonitor& keyMonitor, std::vector<std::string>& techniqueCollection);
+        TechniqueManager(ShaderToggler::KeyMonitor& keyMonitor);
 
         void OnReshadeReloadedEffects(reshade::api::effect_runtime* runtime);
         bool OnReshadeSetTechniqueState(reshade::api::effect_runtime* runtime, reshade::api::effect_technique technique, bool enabled);
@@ -26,7 +26,6 @@ namespace ShaderToggler
 
     private:
         KeyMonitor& keyMonitor;
-        std::vector<std::string>& allTechniques;
         std::vector<std::function<void(reshade::api::effect_runtime*)>> effectsReloadingCallback;
         std::vector<std::function<void(reshade::api::effect_runtime*)>> effectsReloadedCallback;
 

--- a/src/ToggleGroup.cpp
+++ b/src/ToggleGroup.cpp
@@ -126,13 +126,13 @@ namespace ShaderToggler
             const auto& techData = allTechniques.find(techName);
             if (techData != allTechniques.end())
             {
-                _preferredTechniqueData.push_back(&techData->second);
+                _preferredTechniqueData.emplace(&techData->second);
             }
         }
     }
 
 
-    const std::vector<EffectData*>& ToggleGroup::GetPreferredTechniqueData()
+    const std::unordered_set<EffectData*>& ToggleGroup::GetPreferredTechniqueData()
     {
         return _preferredTechniqueData;
     }
@@ -321,6 +321,26 @@ namespace ShaderToggler
     }
 
 
+    static std::vector<std::string> split(std::string& str, char delimiter)
+    {
+        std::vector<std::string> ret;
+
+        if (str.size() > 0) {
+            stringstream ss(str);
+
+            while (ss.good())
+            {
+                string substr;
+                getline(ss, substr, delimiter);
+
+                ret.push_back(substr);
+            }
+        }
+
+        return ret;
+    }
+
+
     void ToggleGroup::loadState(CDataFile& iniFile, int groupCounter)
     {
         if (groupCounter < 0)
@@ -441,14 +461,12 @@ namespace ShaderToggler
         _requeueAfterRTMatchingFailure = iniFile.GetBoolOrDefault("RequeueAfterRTMatchingFailure", sectionRoot, false);
 
         string techniques = iniFile.GetString("Techniques", sectionRoot);
-        if (techniques.size() > 0) {
-            stringstream ss(techniques);
 
-            while (ss.good())
+        vector<string> splitTech = split(techniques, ',');
+        if (splitTech.size() > 0) {
+            for (auto& tech : splitTech)
             {
-                string substr;
-                getline(ss, substr, ',');
-                _preferredTechniques.insert(substr);
+                _preferredTechniques.emplace(tech);
             }
         }
 

--- a/src/ToggleGroup.cpp
+++ b/src/ToggleGroup.cpp
@@ -109,10 +109,32 @@ namespace ShaderToggler
         _cbModePush = other._cbModePush;
         _textureBindingName = other._textureBindingName;
         _preferredTechniques = other._preferredTechniques;
+        _preferredTechniqueData = other._preferredTechniqueData;
         _varOffsetMapping = other._varOffsetMapping;
         _cbCycle = other._cbCycle;
         _srvCycle = other._srvCycle;
         _rtCycle = other._rtCycle;
+    }
+
+
+    void ToggleGroup::AssignPreferredTechniqueData(std::unordered_map<std::string, EffectData>& allTechniques)
+    {
+        _preferredTechniqueData.clear();
+
+        for (auto& techName : _preferredTechniques)
+        {
+            const auto& techData = allTechniques.find(techName);
+            if (techData != allTechniques.end())
+            {
+                _preferredTechniqueData.push_back(&techData->second);
+            }
+        }
+    }
+
+
+    const std::vector<EffectData*>& ToggleGroup::GetPreferredTechniqueData()
+    {
+        return _preferredTechniqueData;
     }
 
 

--- a/src/ToggleGroup.h
+++ b/src/ToggleGroup.h
@@ -39,6 +39,7 @@
 
 #include "reshade.hpp"
 #include "CDataFile.h"
+#include "EffectData.h"
 
 namespace ShaderToggler
 {
@@ -225,6 +226,8 @@ namespace ShaderToggler
         bool AlphaClear() { return false; }
         bool BindingEnabled() { return _isProvidingTextureBinding && _copyTextureBinding; }
         bool BindingClear() { return _clearBindings; }
+        void AssignPreferredTechniqueData(std::unordered_map<std::string, EffectData>& allTechniques);
+        const std::vector<EffectData*>& GetPreferredTechniqueData();
 
     private:
         int _id;
@@ -263,6 +266,7 @@ namespace ShaderToggler
         bool _cbModePush = false;
         std::string _textureBindingName;
         std::unordered_set<std::string> _preferredTechniques;
+        std::vector<EffectData*> _preferredTechniqueData;
         std::unordered_map<std::string, std::tuple<uintptr_t, bool>> _varOffsetMapping;
         DescriptorCycle _cbCycle;
         DescriptorCycle _srvCycle;

--- a/src/ToggleGroup.h
+++ b/src/ToggleGroup.h
@@ -132,7 +132,7 @@ namespace ShaderToggler
         bool isEmpty() const { return _vertexShaderHashes.size() <= 0 && _pixelShaderHashes.size() <= 0; }
         int getId() const { return _id; }
         const std::unordered_set<std::string>& preferredTechniques() const { return _preferredTechniques; }
-        void setPreferredTechniques(std::unordered_set<std::string> techniques) { _preferredTechniques = techniques; }
+        void setPreferredTechniques(std::unordered_set<std::string>& techniques) { _preferredTechniques = techniques; }
         std::unordered_set<uint32_t> getPixelShaderHashes() const { return _pixelShaderHashes; }
         std::unordered_set<uint32_t> getVertexShaderHashes() const { return _vertexShaderHashes; }
         std::unordered_set<uint32_t> getComputeShaderHashes() const { return _computeShaderHashes; }
@@ -227,7 +227,7 @@ namespace ShaderToggler
         bool BindingEnabled() { return _isProvidingTextureBinding && _copyTextureBinding; }
         bool BindingClear() { return _clearBindings; }
         void AssignPreferredTechniqueData(std::unordered_map<std::string, EffectData>& allTechniques);
-        const std::vector<EffectData*>& GetPreferredTechniqueData();
+        const std::unordered_set<EffectData*>& GetPreferredTechniqueData();
 
     private:
         int _id;
@@ -266,7 +266,7 @@ namespace ShaderToggler
         bool _cbModePush = false;
         std::string _textureBindingName;
         std::unordered_set<std::string> _preferredTechniques;
-        std::vector<EffectData*> _preferredTechniqueData;
+        std::unordered_set<EffectData*> _preferredTechniqueData;
         std::unordered_map<std::string, std::tuple<uintptr_t, bool>> _varOffsetMapping;
         DescriptorCycle _cbCycle;
         DescriptorCycle _srvCycle;


### PR DESCRIPTION
Breaking change for groups setting explicit techniques:

REST now separates technique and effect file names to void collisions between effect files defining the same technique name