### PR TITLE
Resource format

### DIFF
--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -10,7 +10,16 @@
 #include "ToggleGroup.h"
 #include "EffectData.h"
 
-using effect_queue = std::unordered_map<EffectData*, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>;
+struct __declspec(novtable) ResourceRenderData final {
+    constexpr ResourceRenderData(ShaderToggler::ToggleGroup* g, uint64_t i, reshade::api::resource r, reshade::api::format f) : group(g), invocationLocation(i), resource(r), format(f) { }
+
+    ShaderToggler::ToggleGroup* group;
+    uint64_t invocationLocation;
+    reshade::api::resource resource;
+    reshade::api::format format;
+};
+
+using effect_queue = std::unordered_map<EffectData*, ResourceRenderData>;
 using binding_queue = std::unordered_map<ShaderToggler::ToggleGroup*, std::tuple<uint64_t, reshade::api::resource>>;
 
 struct __declspec(novtable) ShaderData final {

--- a/src/PipelinePrivateData.h
+++ b/src/PipelinePrivateData.h
@@ -11,6 +11,7 @@
 #include "EffectData.h"
 
 struct __declspec(novtable) ResourceRenderData final {
+    constexpr ResourceRenderData() : group(nullptr), invocationLocation(0), resource({0}), format(reshade::api::format::unknown) { }
     constexpr ResourceRenderData(ShaderToggler::ToggleGroup* g, uint64_t i, reshade::api::resource r, reshade::api::format f) : group(g), invocationLocation(i), resource(r), format(f) { }
 
     ShaderToggler::ToggleGroup* group;
@@ -20,7 +21,7 @@ struct __declspec(novtable) ResourceRenderData final {
 };
 
 using effect_queue = std::unordered_map<EffectData*, ResourceRenderData>;
-using binding_queue = std::unordered_map<ShaderToggler::ToggleGroup*, std::tuple<uint64_t, reshade::api::resource>>;
+using binding_queue = std::unordered_map<ShaderToggler::ToggleGroup*, ResourceRenderData>;
 
 struct __declspec(novtable) ShaderData final {
     uint32_t activeShaderHash = -1;
@@ -82,6 +83,7 @@ struct __declspec(novtable) HuntPreview final
     uint32_t width = 0;
     uint32_t height = 0;
     reshade::api::format format = reshade::api::format::unknown;
+    reshade::api::format view_format = reshade::api::format::unknown;
     reshade::api::resource_desc target_desc;
     bool recreate_preview = false;
 

--- a/src/RenderingBindingManager.cpp
+++ b/src/RenderingBindingManager.cpp
@@ -155,11 +155,11 @@ void RenderingBindingManager::_QueueOrDequeue(
         // Set views during draw call since we can be sure the correct ones are bound at that point
         if (!callLocation && view == 0)
         {
-            resource active_target = RenderingManager::GetCurrentResourceView(cmd_list, deviceData, group, commandListData, layoutIndex, action);
+            ResourceViewData active_data = RenderingManager::GetCurrentResourceView(cmd_list, deviceData, group, commandListData, layoutIndex, action);
 
-            if (active_target != 0)
+            if (active_data.resource != 0)
             {
-                view = active_target;
+                view = active_data.resource;
             }
             else if (group->getRequeueAfterRTMatchingFailure())
             {

--- a/src/RenderingBindingManager.cpp
+++ b/src/RenderingBindingManager.cpp
@@ -100,7 +100,7 @@ bool RenderingBindingManager::CreateTextureBinding(effect_runtime* runtime, reso
     return _CreateTextureBinding(runtime, res, srv, rtv, format, frame_width, frame_height, 1);
 }
 
-uint32_t RenderingBindingManager::UpdateTextureBinding(effect_runtime* runtime, ToggleGroup* group, resource res, const resource_desc& desc)
+uint32_t RenderingBindingManager::UpdateTextureBinding(effect_runtime* runtime, ToggleGroup* group, resource res, const resource_desc& desc, reshade::api::format viewformat)
 {
     DeviceDataContainer& data = runtime->get_device()->get_private_data<DeviceDataContainer>();
     GroupResource& groupResource = group->GetGroupResource(ShaderToggler::GroupResourceType::RESOURCE_BINDING);
@@ -110,6 +110,7 @@ uint32_t RenderingBindingManager::UpdateTextureBinding(effect_runtime* runtime, 
     {
         groupResource.target_description = desc;
         groupResource.res = { 0 };
+        groupResource.view_format = viewformat;
         groupResource.rtv = { 0 };
         groupResource.rtv_srgb = { 0 };
         groupResource.srv = { 0 };
@@ -123,6 +124,7 @@ uint32_t RenderingBindingManager::UpdateTextureBinding(effect_runtime* runtime, 
     if (!toggleGroupResources.IsCompatibleWithGroupFormat(runtime->get_device(), ShaderToggler::GroupResourceType::RESOURCE_BINDING, res, group))
     {
         groupResource.target_description = desc;
+        groupResource.view_format = viewformat;
         groupResource.state = ShaderToggler::GroupResourceState::RESOURCE_INVALID;
         runtime->update_texture_bindings(group->getTextureBindingName().c_str(), empty_srv, empty_srv);
 
@@ -151,15 +153,15 @@ void RenderingBindingManager::_QueueOrDequeue(
     for (auto it = queue.begin(); it != queue.end();)
     {
         auto& [group, data] = *it;
-        auto& [loc, view] = data;
         // Set views during draw call since we can be sure the correct ones are bound at that point
-        if (!callLocation && view == 0)
+        if (!callLocation && data.resource == 0)
         {
             ResourceViewData active_data = RenderingManager::GetCurrentResourceView(cmd_list, deviceData, group, commandListData, layoutIndex, action);
 
             if (active_data.resource != 0)
             {
-                view = active_data.resource;
+                data.resource = active_data.resource;
+                data.format = active_data.format;
             }
             else if (group->getRequeueAfterRTMatchingFailure())
             {
@@ -175,7 +177,7 @@ void RenderingBindingManager::_QueueOrDequeue(
         }
 
         // Queue updates depending on the place their supposed to be called at
-        if (view != 0 && (!callLocation && !loc || callLocation & loc))
+        if (data.resource != 0 && (!callLocation && !data.invocationLocation || callLocation & data.invocationLocation))
         {
             immediateQueue.insert(group);
         }
@@ -201,9 +203,7 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
     {
         if (toUpdateBindings.contains(group) && !deviceData.bindingsUpdated.contains(group))
         {
-            resource active_resource = std::get<1>(bindingData);
-
-            if (active_resource == 0)
+            if (bindingData.resource == 0)
             {
                 continue;
             }
@@ -212,7 +212,7 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
 
             if (!group->getCopyTextureBinding())
             {
-                GlobalResourceView& view = resourceManager.GetResourceView(runtime->get_device(), active_resource.handle);
+                GlobalResourceView& view = resourceManager.GetResourceView(runtime->get_device(), bindingData);
                 resource_view view_non_srgb = view.srv;
                 resource_view view_srgb = view.rtv_srgb;
 
@@ -221,15 +221,16 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
                     return;
                 }
 
-                resource_desc resDesc = runtime->get_device()->get_resource_desc(active_resource);
+                resource_desc resDesc = runtime->get_device()->get_resource_desc(bindingData.resource);
 
                 resource target_res = bindingResource.res;
 
-                if (target_res != active_resource || bindingResource.state == ShaderToggler::GroupResourceState::RESOURCE_CLEARED)
+                if (target_res != bindingData.resource || bindingResource.state == ShaderToggler::GroupResourceState::RESOURCE_CLEARED)
                 {
                     runtime->update_texture_bindings(group->getTextureBindingName().c_str(), view_non_srgb, view_srgb);
 
-                    bindingResource.res = active_resource;
+                    bindingResource.res = bindingData.resource;
+                    bindingResource.view_format = bindingData.format;
                     bindingResource.target_description = resDesc;
                     bindingResource.srv = view_non_srgb;
                     bindingResource.owning = false;
@@ -238,15 +239,15 @@ void RenderingBindingManager::_UpdateTextureBindings(command_list* cmd_list,
             }
             else
             {
-                resource_desc resDesc = runtime->get_device()->get_resource_desc(active_resource);
+                resource_desc resDesc = runtime->get_device()->get_resource_desc(bindingData.resource);
 
-                uint32_t retUpdate = UpdateTextureBinding(runtime, group, active_resource, resDesc);
+                uint32_t retUpdate = UpdateTextureBinding(runtime, group, bindingData.resource, resDesc, bindingData.format);
 
                 resource target_res = bindingResource.res;
 
                 if (retUpdate && target_res != 0)
                 {
-                    cmd_list->copy_resource(active_resource, target_res);
+                    cmd_list->copy_resource(bindingData.resource, target_res);
 
                     if (group->getFlipBufferBinding() && bindingResource.rtv != 0 && runtimeData.specialEffects[REST_FLIP].technique != 0)
                     {
@@ -353,10 +354,16 @@ void RenderingBindingManager::ClearUnmatchedTextureBindings(reshade::api::comman
         ToggleGroup& group = groupData.second;
         GroupResource& resources = group.GetGroupResource(ShaderToggler::GroupResourceType::RESOURCE_BINDING);
 
-        if (!data.bindingsUpdated.contains(&group) && resources.clear_on_miss() && empty_srv != 0 && resources.state != ShaderToggler::GroupResourceState::RESOURCE_CLEARED)
+        if (!data.bindingsUpdated.contains(&group) && (resources.clear_on_miss() && empty_srv != 0 && resources.state != ShaderToggler::GroupResourceState::RESOURCE_CLEARED || !resources.owning))
         {
             data.current_runtime->update_texture_bindings(group.getTextureBindingName().c_str(), empty_srv, empty_srv);
             resources.state = ShaderToggler::GroupResourceState::RESOURCE_CLEARED;
+
+            if (!resources.owning)
+            {
+                resources.srv = { 0 };
+                resources.res = { 0 };
+            }
         }
     }
 

--- a/src/RenderingBindingManager.h
+++ b/src/RenderingBindingManager.h
@@ -13,7 +13,7 @@ namespace Rendering
 
         bool CreateTextureBinding(reshade::api::effect_runtime* runtime, reshade::api::resource* res, reshade::api::resource_view* srv, reshade::api::resource_view* rtv, const reshade::api::resource_desc& desc);
         bool CreateTextureBinding(reshade::api::effect_runtime* runtime, reshade::api::resource* res, reshade::api::resource_view* srv, reshade::api::resource_view* rtv, reshade::api::format format);
-        uint32_t UpdateTextureBinding(reshade::api::effect_runtime* runtime, ShaderToggler::ToggleGroup* group, reshade::api::resource res, const reshade::api::resource_desc& desc);
+        uint32_t UpdateTextureBinding(reshade::api::effect_runtime* runtime, ShaderToggler::ToggleGroup* group, reshade::api::resource res, const reshade::api::resource_desc& desc, reshade::api::format viewformat);
         void InitTextureBingings(reshade::api::effect_runtime* runtime);
         void DisposeTextureBindings(reshade::api::device* device);
         void UpdateTextureBindings(reshade::api::command_list* cmd_list, uint64_t callLocation = CALL_DRAW, uint64_t invocation = MATCH_NONE);

--- a/src/RenderingEffectManager.cpp
+++ b/src/RenderingEffectManager.cpp
@@ -58,7 +58,7 @@ bool RenderingEffectManager::_RenderEffects(
     command_list* cmd_list,
     DeviceDataContainer& deviceData,
     RuntimeDataContainer& runtimeData,
-    const unordered_map<EffectData*, tuple<ToggleGroup*, uint64_t, resource>>& techniquesToRender,
+    const effect_queue& techniquesToRender,
     vector<EffectData*>& removalList,
     const unordered_set<EffectData*>& toRenderNames)
 {
@@ -80,12 +80,11 @@ bool RenderingEffectManager::_RenderEffects(
         if (sTech->first->enabled && !sTech->first->rendered && toRenderNames.contains(sTech->first))
         {
             const auto& [techName, techData] = *sTech;
-            const auto& [group, _, active_resource] = techData;
 
-            auto& [gEffects, gResource] = groupTechMap[group];
+            auto& [gEffects, gResource] = groupTechMap[techData.group];
 
             gEffects.push_back(sTech->first);
-            gResource = active_resource;
+            gResource = techData.resource;
         }
     }
 

--- a/src/RenderingEffectManager.h
+++ b/src/RenderingEffectManager.h
@@ -25,7 +25,7 @@ namespace Rendering
             reshade::api::command_list* cmd_list,
             DeviceDataContainer& deviceData,
             RuntimeDataContainer& runtimeData,
-            const std::unordered_map<EffectData*, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& techniquesToRender,
+            const effect_queue& techniquesToRender,
             std::vector<EffectData*>& removalList,
             const std::unordered_set<EffectData*>& toRenderNames);
     };

--- a/src/RenderingManager.h
+++ b/src/RenderingManager.h
@@ -55,10 +55,18 @@ namespace Rendering
     constexpr uint64_t CHECK_MATCH_BIND_RENDERTARGET_BINDING = MATCH_BINDING << (CALL_BIND_RENDER_TARGET * MATCH_DELIMITER);
     constexpr uint64_t CHECK_MATCH_BIND_RENDERTARGET_PREVIEW = MATCH_PREVIEW << (CALL_BIND_RENDER_TARGET * MATCH_DELIMITER);
 
+    struct __declspec(novtable) ResourceViewData final {
+        constexpr ResourceViewData() : resource({ 0 }), format(reshade::api::format::unknown) { }
+        constexpr ResourceViewData(reshade::api::resource r, reshade::api::format f) : resource(r), format(f) { }
+
+        reshade::api::resource resource;
+        reshade::api::format format;
+    };
+
     class __declspec(novtable) RenderingManager final
     {
     public:
-        static const reshade::api::resource GetCurrentResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
+        static const ResourceViewData GetCurrentResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
         static bool check_aspect_ratio(float width_to_check, float height_to_check, uint32_t width, uint32_t height, uint32_t matchingMode);
         
         static void EnumerateTechniques(reshade::api::effect_runtime* runtime, std::function<void(reshade::api::effect_runtime*, reshade::api::effect_technique, std::string&, std::string&)> func);
@@ -66,7 +74,7 @@ namespace Rendering
             reshade::api::command_list* cmd_list,
             DeviceDataContainer& deviceData,
             CommandListDataContainer& commandListData,
-            std::unordered_map<EffectData*, std::tuple<ShaderToggler::ToggleGroup*, uint64_t, reshade::api::resource>>& queue,
+            effect_queue& queue,
             std::unordered_set<EffectData*>& immediateQueue,
             uint64_t callLocation,
             uint32_t layoutIndex,

--- a/src/RenderingPreviewManager.cpp
+++ b/src/RenderingPreviewManager.cpp
@@ -17,13 +17,13 @@ RenderingPreviewManager::~RenderingPreviewManager()
 {
 }
 
-const resource RenderingPreviewManager::GetCurrentPreviewResourceView(command_list* cmd_list, DeviceDataContainer& deviceData, const ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action)
+const ResourceViewData RenderingPreviewManager::GetCurrentPreviewResourceView(command_list* cmd_list, DeviceDataContainer& deviceData, const ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action)
 {
-    resource active_target = { 0 };
+    ResourceViewData active_data;
 
     if (deviceData.current_runtime == nullptr)
     {
-        return active_target;
+        return active_data;
     }
 
     device* device = deviceData.current_runtime->get_device();
@@ -41,11 +41,12 @@ const resource RenderingPreviewManager::GetCurrentPreviewResourceView(command_li
         if (rs == 0)
         {
             // Render targets may not have a resource bound in D3D12, in which case writes to them are discarded
-            return active_target;
+            return active_data;
         }
 
         // Don't apply effects to non-RGB buffers
         resource_desc desc = device->get_resource_desc(rs);
+        resource_view_desc view_desc = device->get_resource_view_desc(rtvs[index]);
 
         // Make sure our target matches swap buffer dimensions when applying effects or it's explicitly requested
         if (group->getMatchSwapchainResolution() < ShaderToggler::SWAPCHAIN_MATCH_MODE_NONE)
@@ -57,14 +58,15 @@ const resource RenderingPreviewManager::GetCurrentPreviewResourceView(command_li
                 !RenderingManager::check_aspect_ratio(static_cast<float>(desc.texture.width), static_cast<float>(desc.texture.height), width, height, group->getMatchSwapchainResolution())) ||
                 (group->getMatchSwapchainResolution() == ShaderToggler::SWAPCHAIN_MATCH_MODE_RESOLUTION && (width != desc.texture.width || height != desc.texture.height)))
             {
-                return active_target;
+                return active_data;
             }
         }
 
-        active_target = rs;
+        active_data.resource = rs;
+        active_data.format = view_desc.format;
     }
 
-    return active_target;
+    return active_data;
 }
 
 void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t callLocation, uint64_t invocation)
@@ -92,7 +94,7 @@ void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t cal
     // Set views during draw call since we can be sure the correct ones are bound at that point
     if (!callLocation && deviceData.huntPreview.target == 0)
     {
-        resource active_target = resource{ 0 };
+        ResourceViewData active_target;
 
         if (invocation & MATCH_PREVIEW_PS)
         {
@@ -107,13 +109,15 @@ void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t cal
             active_target = GetCurrentPreviewResourceView(cmd_list, deviceData, &group, commandListData, 2, invocation & MATCH_PREVIEW_CS);
         }
 
-        if (active_target != 0)
+        if (active_target.resource != 0)
         {
-            resource_desc desc = device->get_resource_desc(active_target);
+            resource_desc desc = device->get_resource_desc(active_target.resource);
             //cmd_list->get_private_data<state_tracking>().start_resource_barrier_tracking(res, resource_usage::render_target);
 
-            deviceData.huntPreview.target = active_target;
+            deviceData.huntPreview.target = active_target.resource;
+            deviceData.huntPreview.target_desc = desc;
             deviceData.huntPreview.format = desc.texture.format;
+            deviceData.huntPreview.view_format = active_target.format;
             deviceData.huntPreview.width = desc.texture.width;
             deviceData.huntPreview.height = desc.texture.height;
         }
@@ -139,7 +143,6 @@ void RenderingPreviewManager::UpdatePreview(command_list* cmd_list, uint64_t cal
 
         if (!resourceManager.IsCompatibleWithPreviewFormat(deviceData.current_runtime, rs))
         {
-            deviceData.huntPreview.target_desc = cmd_list->get_device()->get_resource_desc(rs);
             deviceData.huntPreview.recreate_preview = true;
         }
         else

--- a/src/RenderingPreviewManager.h
+++ b/src/RenderingPreviewManager.h
@@ -12,7 +12,7 @@ namespace Rendering
         ~RenderingPreviewManager();
 
         void UpdatePreview(reshade::api::command_list* cmd_list, uint64_t callLocation, uint64_t invocation);
-        const reshade::api::resource GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
+        const ResourceViewData GetCurrentPreviewResourceView(reshade::api::command_list* cmd_list, DeviceDataContainer& deviceData, const ShaderToggler::ToggleGroup* group, CommandListDataContainer& commandListData, uint32_t descIndex, uint64_t action);
 
     private:
         AddonImGui::AddonUIData& uiData;

--- a/src/RenderingQueueManager.cpp
+++ b/src/RenderingQueueManager.cpp
@@ -82,7 +82,7 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
                         {
                             if (!sData.techniquesToRender.contains(techData))
                             {
-                                sData.techniquesToRender.emplace(techData, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
+                                sData.techniquesToRender.emplace(techData, ResourceRenderData{ group, group->getInvocationLocation(), resource{ 0 }, format::unknown });
                                 queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
                             }
                         }
@@ -95,7 +95,7 @@ void RenderingQueueManager::_CheckCallForCommandList(ShaderData& sData, CommandL
                     {
                         if (!eff->rendered && !sData.techniquesToRender.contains(eff))
                         {
-                            sData.techniquesToRender.emplace(eff, std::make_tuple(group, group->getInvocationLocation(), resource{ 0 }));
+                            sData.techniquesToRender.emplace(eff, ResourceRenderData{ group, group->getInvocationLocation(), resource{ 0 }, format::unknown });
                             queue_mask |= (match_effect << (group->getInvocationLocation() * MATCH_DELIMITER)) | (match_effect << (CALL_DRAW * MATCH_DELIMITER));
                         }
                     }
@@ -141,8 +141,8 @@ void RenderingQueueManager::_RescheduleGroups(ShaderData& sData, CommandListData
 
     for (const auto& tech : sData.techniquesToRender)
     {
-        const ToggleGroup* group = std::get<0>(tech.second);
-        const resource res = std::get<2>(tech.second);
+        const ToggleGroup* group = tech.second.group;
+        const resource res = tech.second.resource;
 
         if (res == 0 && group->getRequeueAfterRTMatchingFailure())
         {
@@ -209,7 +209,7 @@ static void clearStage(CommandListDataContainer& commandListData, effect_queue& 
     {
         for (auto it = queuedTasks.begin(); it != queuedTasks.end();)
         {
-            uint64_t callLocation = std::get<1>(it->second);
+            uint64_t callLocation = it->second.invocationLocation;
             if (callLocation == location)
             {
                 it = queuedTasks.erase(it);

--- a/src/ResourceManager.h
+++ b/src/ResourceManager.h
@@ -43,7 +43,6 @@ namespace Rendering
     {
         constexpr GlobalResourceView() : resource_handle { 0 }, rtv { 0 }, rtv_srgb { 0 }, srv { 0 }, srv_srgb { 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED) { }
         constexpr GlobalResourceView(uint64_t handle) : resource_handle{ handle }, rtv{ 0 }, rtv_srgb{ 0 }, srv{ 0 }, srv_srgb{ 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED) { }
-        constexpr GlobalResourceView(reshade::api::resource_desc desc) : resource_handle { 0 }, rtv { 0 }, rtv_srgb{ 0 }, srv{ 0 }, srv_srgb{ 0 }, state(GlobalResourceState::RESOURCE_UNINITIALIZED) { }
 
         uint64_t resource_handle;
         reshade::api::resource_view rtv;
@@ -82,7 +81,8 @@ namespace Rendering
         void OnEffectsReloading(reshade::api::effect_runtime* runtime);
         void OnEffectsReloaded(reshade::api::effect_runtime* runtime);
 
-        GlobalResourceView& GetResourceView(reshade::api::device* device, uint64_t handle);
+        GlobalResourceView& GetResourceView(reshade::api::device* device, const ResourceRenderData& data);
+        GlobalResourceView& GetResourceView(reshade::api::device* device, uint64_t handle, reshade::api::format format = reshade::api::format::unknown);
         void CheckResourceViews(reshade::api::effect_runtime* runtime);
 
         static EmbeddedResourceData GetResourceData(uint16_t id);
@@ -91,7 +91,7 @@ namespace Rendering
         reshade::api::resource_view dummy_rtv;
     private:
         void DisposeView(reshade::api::device* device, const GlobalResourceView& views);
-        void CreateViews(reshade::api::device* device, GlobalResourceView& gview);
+        void CreateViews(reshade::api::device* device, GlobalResourceView& gview, reshade::api::format format = reshade::api::format::unknown);
         static ResourceShimType ResolveResourceShimType(const std::string&);
 
         ResourceShimType _shimType = ResourceShimType::Resource_Shim_None;

--- a/src/ToggleGroup.cpp
+++ b/src/ToggleGroup.cpp
@@ -59,9 +59,9 @@ namespace ShaderToggler
         _srvCycle = CYCLE_NONE;
         _rtCycle = CYCLE_NONE;
 
-        _group_buffers[static_cast<uint32_t>(GroupResourceType::RESOURCE_ALPHA)] = { {}, {}, {}, {}, {}, [&]() { return _preserveAlpha; }, [&]() { return false; }, GroupResourceState::RESOURCE_INVALID, true };
-        _group_buffers[static_cast<uint32_t>(GroupResourceType::RESOURCE_BINDING)] = { {}, {}, {}, {}, {}, [&]() { return _copyTextureBinding && _isProvidingTextureBinding; }, [&]() { return _clearBindings; }, GroupResourceState::RESOURCE_INVALID, true };
-        _group_buffers[static_cast<uint32_t>(GroupResourceType::RESOURCE_CONSTANTS_COPY)] = { {}, {}, {}, {}, {}, [&]() { return _extractConstants; }, [&]() { return false; }, GroupResourceState::RESOURCE_INVALID, true };
+        _group_buffers[static_cast<uint32_t>(GroupResourceType::RESOURCE_ALPHA)] = { {}, {}, {}, {}, {}, {}, [&]() { return _preserveAlpha; }, [&]() { return false; }, GroupResourceState::RESOURCE_INVALID, true };
+        _group_buffers[static_cast<uint32_t>(GroupResourceType::RESOURCE_BINDING)] = { {}, {}, {}, {}, {}, {}, [&]() { return _copyTextureBinding && _isProvidingTextureBinding; }, [&]() { return _clearBindings; }, GroupResourceState::RESOURCE_INVALID, true };
+        _group_buffers[static_cast<uint32_t>(GroupResourceType::RESOURCE_CONSTANTS_COPY)] = { {}, {}, {}, {}, {}, {}, [&]() { return _extractConstants; }, [&]() { return false; }, GroupResourceState::RESOURCE_INVALID, true };
     }
 
 

--- a/src/ToggleGroup.h
+++ b/src/ToggleGroup.h
@@ -79,17 +79,15 @@ namespace ShaderToggler
     struct __declspec(novtable) GroupResource final
     {
         reshade::api::resource res;
+        reshade::api::format view_format;
         reshade::api::resource_view rtv;
         reshade::api::resource_view rtv_srgb;
         reshade::api::resource_view srv;
         reshade::api::resource_desc target_description;
         std::function<bool()> enabled;
         std::function<bool()> clear_on_miss;
-        //bool recreate;
         GroupResourceState state;
         bool owning;
-        //bool cleared;
-        //bool recreated;
     };
 
     class ToggleGroup
@@ -97,8 +95,7 @@ namespace ShaderToggler
     public:
         ToggleGroup(std::string name, int Id);
         ToggleGroup();
-        //ToggleGroup(ToggleGroup&&) noexcept = default;
-        ToggleGroup(const ToggleGroup& other); // no copy
+        ToggleGroup(const ToggleGroup& other);
 
         static int getNewGroupId();
 

--- a/src/ToggleGroupResourceManager.cpp
+++ b/src/ToggleGroupResourceManager.cpp
@@ -208,17 +208,17 @@ void ToggleGroupResourceManager::CheckGroupBuffers(reshade::api::effect_runtime*
                     reshade::log_message(reshade::log_level::error, "Failed to create group render target!");
                 }
 
-                if (validRT && resources.res != 0 && !runtime->get_device()->create_resource_view(resources.res, resource_usage::shader_resource, resource_view_desc(format_to_default_typed(group_desc.texture.format, 0)), &resources.srv))
+                if (validRT && resources.res != 0 && !runtime->get_device()->create_resource_view(resources.res, resource_usage::shader_resource, resource_view_desc(format_to_default_typed(resources.view_format, 0)), &resources.srv))
                 {
                     reshade::log_message(reshade::log_level::error, "Failed to create group shader resource view!");
                 }
 
-                if (validRT && resources.res != 0 && !runtime->get_device()->create_resource_view(resources.res, resource_usage::render_target, resource_view_desc(format_to_default_typed(group_desc.texture.format, 0)), &resources.rtv))
+                if (validRT && resources.res != 0 && !runtime->get_device()->create_resource_view(resources.res, resource_usage::render_target, resource_view_desc(format_to_default_typed(resources.view_format, 0)), &resources.rtv))
                 {
                     reshade::log_message(reshade::log_level::error, "Failed to create group render target view!");
                 }
 
-                if (resources.res != 0 && !runtime->get_device()->create_resource_view(resources.res, resource_usage::render_target, resource_view_desc(format_to_default_typed(group_desc.texture.format, 1)), &resources.rtv_srgb))
+                if (resources.res != 0 && !runtime->get_device()->create_resource_view(resources.res, resource_usage::render_target, resource_view_desc(format_to_default_typed(resources.view_format, 1)), &resources.rtv_srgb))
                 {
                     reshade::log_message(reshade::log_level::error, "Failed to create group SRGB render target view!");
                 }


### PR DESCRIPTION
Create utility views in the same format as the ones matched. Using default ones leads to issues in some instances